### PR TITLE
Add script to generate DBT tables from C sources

### DIFF
--- a/Tables/auto_tables.dbt
+++ b/Tables/auto_tables.dbt
@@ -1,0 +1,22218 @@
+@gsw.subsystem: AUTO
+@classname: FC
+
+table ac_atc_table_type {
+  @buildstruct!
+  .Inertia11Lim[1]:
+    @datatype: dReal
+    @default: 700.0
+    @description: "Inertia11Lim"
+
+  .Inertia11Lim[2]:
+    @datatype: dReal
+    @default: 1100.0
+    @description: "Inertia11Lim"
+
+  .Inertia12Lim[1]:
+    @datatype: dReal
+    @default: -40.0
+    @description: "Inertia12Lim"
+
+  .Inertia12Lim[2]:
+    @datatype: dReal
+    @default: 40.0
+    @description: "Inertia12Lim"
+
+  .Inertia13Lim[1]:
+    @datatype: dReal
+    @default: -40.0
+    @description: "Inertia13Lim"
+
+  .Inertia13Lim[2]:
+    @datatype: dReal
+    @default: 40.0
+    @description: "Inertia13Lim"
+
+  .Inertia22Lim[1]:
+    @datatype: dReal
+    @default: 700.0
+    @description: "Inertia22Lim"
+
+  .Inertia22Lim[2]:
+    @datatype: dReal
+    @default: 1100.0
+    @description: "Inertia22Lim"
+
+  .Inertia23Lim[1]:
+    @datatype: dReal
+    @default: -40.0
+    @description: "Inertia23Lim"
+
+  .Inertia23Lim[2]:
+    @datatype: dReal
+    @default: 40.0
+    @description: "Inertia23Lim"
+
+  .Inertia33Lim[1]:
+    @datatype: dReal
+    @default: 200.0
+    @description: "Inertia33Lim"
+
+  .Inertia33Lim[2]:
+    @datatype: dReal
+    @default: 400.0
+    @description: "Inertia33Lim"
+
+  .IscInit:
+    @datatype: uMatrix
+    @default: {{{ 916.925, -23.449, -10.286 }, { -23.449, 883.866, 1.574 }, { -10.286, 1.574, 340.438 }}}
+    @description: "Standby RateNull CoarseSunAcq SunPoint DeltaV Normal Target Mission --- Torque Enable Flags, NA"
+
+  .EnableCtlTorque[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "EnableCtlTorque"
+
+  .EnableCtlTorque[2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCtlTorque"
+
+  .EnableCtlTorque[3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCtlTorque"
+
+  .EnableCtlTorque[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCtlTorque"
+
+  .EnableCtlTorque[5]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCtlTorque"
+
+  .EnableCtlTorque[6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCtlTorque"
+
+  .EnableCtlTorque[7]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCtlTorque"
+
+  .EnableCtlTorque[8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCtlTorque"
+
+  .EnableGyrTorque[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "EnableGyrTorque"
+
+  .EnableGyrTorque[2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableGyrTorque"
+
+  .EnableGyrTorque[3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableGyrTorque"
+
+  .EnableGyrTorque[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableGyrTorque"
+
+  .EnableGyrTorque[5]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableGyrTorque"
+
+  .EnableGyrTorque[6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableGyrTorque"
+
+  .EnableGyrTorque[7]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableGyrTorque"
+
+  .EnableGyrTorque[8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableGyrTorque"
+
+  .EnableCmdTorque[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "EnableCmdTorque"
+
+  .EnableCmdTorque[2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCmdTorque"
+
+  .EnableCmdTorque[3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCmdTorque"
+
+  .EnableCmdTorque[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCmdTorque"
+
+  .EnableCmdTorque[5]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCmdTorque"
+
+  .EnableCmdTorque[6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCmdTorque"
+
+  .EnableCmdTorque[7]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCmdTorque"
+
+  .EnableCmdTorque[8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "EnableCmdTorque"
+
+  .PassiveModeEnabled[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "PassiveModeEnabled [True/False ] PD_FAULT"
+
+  .PassiveModeEnabled[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_IDLE"
+
+  .PassiveModeEnabled[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_HOLD"
+
+  .PassiveModeEnabled[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_SLEWING"
+
+  .PassiveModeEnabled[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_TRACKING"
+
+  .PassiveModeEnabled[6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_DECELERATE"
+
+  .PassiveModeEnabled[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_TRACK_TABLE"
+
+  .PassiveModeEnabled[8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_COMM_ANGLE"
+
+  .EnableLPF[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[1][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[2][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[3][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[3][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[4][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[4][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[5][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[6][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[7][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[7][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[8][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[8][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .EnableLPF[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Mission --- X-Axis Torque Filter ..."
+
+  .TorqueFilX:
+    @datatype: lpf_param_type
+    @default: { 3, 0, 0, 0, 1.216355483255598E-1, {{ 1.437848788711524E+0, 9.999999999999927E-1 }, { -7.795636228047393E-1, 9.999999999999841E-1 }, { -1.986179155592837E-1, 1.000000000000023E+0 }}, {{ -9.106593886195251E-1, 7.978000333789819E-1 }, { -4.696648399744229E-1, 4.127456171133396E-1 }, { 3.350109308789905E-2, 6.531978171884680E-2 }}, }
+    @description: "--- Y-Axis Torque Filter ..."
+
+  .TorqueFilY:
+    @datatype: lpf_param_type
+    @default: { 3, 0, 0, 0, 1.216355483255598E-1, {{ 1.437848788711524E+0, 9.999999999999927E-1 }, { -7.795636228047393E-1, 9.999999999999841E-1 }, { -1.986179155592837E-1, 1.000000000000023E+0 }}, {{ -9.106593886195251E-1, 7.978000333789819E-1 }, { -4.696648399744229E-1, 4.127456171133396E-1 }, { 3.350109308789905E-2, 6.531978171884680E-2 }}, }
+    @description: "--- Z-Axis Torque Filter ..."
+
+  .TorqueFilZ:
+    @datatype: lpf_param_type
+    @default: { 3, 0, 0, 0, 1.216355483255598E-1, {{ 1.437848788711524E+0, 9.999999999999927E-1 }, { -7.795636228047393E-1, 9.999999999999841E-1 }, { -1.986179155592837E-1, 1.000000000000023E+0 }}, {{ -9.106593886195251E-1, 7.978000333789819E-1 }, { -4.696648399744229E-1, 4.127456171133396E-1 }, { 3.350109308789905E-2, 6.531978171884680E-2 }}, }
+
+  .MaxPassiveDurationCnt:
+    @datatype: uWord
+    @default: (180 * NUM_AC_CYCLES)
+    @description: "MaxPassiveDurationCnt"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .Spare[3]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .RateNullThetaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 0.0, 0.0, 0.0 }}
+    @description: "--- Attitude Error Limits ... RateNullThetaErrBdyLmt, rad"
+
+  .CSAThetaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 2.00E+0*DEG_2_RAD, 2.00E+0*DEG_2_RAD, 2.00E+0*DEG_2_RAD }}
+    @description: "CSAThetaErrBdyLmt, rad"
+
+  .CSPThetaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 2.00E+0*DEG_2_RAD, 2.00E+0*DEG_2_RAD, 2.00E+0*DEG_2_RAD }}
+    @description: "CSPThetaErrBdyLmt, rad"
+
+  .TgtPntThetaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD }}
+    @description: "TgtPntThetaErrBdyLmt, rad"
+
+  .NormalThetaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 2.50E-1*DEG_2_RAD, 2.50E-1*DEG_2_RAD, 2.50E-1*DEG_2_RAD }}
+    @description: "NormalThetaErrBdyLmt, rad"
+
+  .MissionThetaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 2.50E-1*DEG_2_RAD, 2.50E-1*DEG_2_RAD, 2.50E-1*DEG_2_RAD }}
+    @description: "MissionThetaErrBdyLmt, rad"
+
+  .DeltaVThetaErrBdyLmtBRE:
+    @datatype: uVector
+    @default: {{ 2.50E+0*DEG_2_RAD, 2.50E+0*DEG_2_RAD, 2.50E+0*DEG_2_RAD }}
+    @description: "DeltaVThetaErrBdyLmtBRE, rad"
+
+  .DeltaVThetaErrBdyLmtREA:
+    @datatype: uVector
+    @default: {{ 2.50E+0*DEG_2_RAD, 2.50E+0*DEG_2_RAD, 2.50E+0*DEG_2_RAD }}
+    @description: "DeltaVThetaErrBdyLmtREA, rad --- Rate Error Limits ..."
+
+  .RateNullOmegaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 2.50E-1*DEG_2_RAD, 2.50E-1*DEG_2_RAD, 2.50E-1*DEG_2_RAD }}
+    @description: "RateNullOmegaErrBdyLmt, rad/sec"
+
+  .CSAOmegaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD }}
+    @description: "CSAOmegaErrBdyLmt, rad/sec"
+
+  .CSPOmegaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD }}
+    @description: "CSPOmegaErrBdyLmt, rad/sec"
+
+  .TgtPntOmegaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 6.00E-1*DEG_2_RAD, 6.00E-1*DEG_2_RAD, 6.00E-1*DEG_2_RAD }}
+    @description: "TgtPntOmegaErrBdyLmt, rad/sec"
+
+  .NormalOmegaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD }}
+    @description: "NormalOmegaErrBdyLmt, rad/sec"
+
+  .MissionOmegaErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 2.00E-2*DEG_2_RAD, 2.00E-2*DEG_2_RAD, 2.00E-2*DEG_2_RAD }}
+    @description: "MissionOmegaErrBdyLmt, rad/sec"
+
+  .DeltaVOmegaErrBdyLmtBRE:
+    @datatype: uVector
+    @default: {{ 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD }}
+    @description: "DeltaVOmegaErrBdyLmtBRE, rad/sec"
+
+  .DeltaVOmegaErrBdyLmtREA:
+    @datatype: uVector
+    @default: {{ 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD }}
+    @description: "DeltaVOmegaErrBdyLmtREA, rad/sec --- Integral Error Limits ..."
+
+  .RateNullIntegralErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 0.0, 0.0, 0.0 }}
+    @description: "RateNullIntegralErrBdyLmt, sec"
+
+  .CSAIntegralErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 0.0, 0.0, 0.0 }}
+    @description: "CSAIntegralErrBdyLmt, sec"
+
+  .CSPIntegralErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 0.0, 0.0, 0.0 }}
+    @description: "CSPIntegralErrBdyLmt, sec"
+
+  .TgtPntIntegralErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 0.0, 0.0, 0.0 }}
+    @description: "TgtPntIntegralErrBdyLmt, sec"
+
+  .NormalIntegralErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD, 1.50E+0*DEG_2_RAD }}
+    @description: "NormalIntegralErrBdyLmt, sec"
+
+  .MissionIntegralErrBdyLmt:
+    @datatype: uVector
+    @default: {{ 5.00E+0*DEG_2_RAD, 5.00E+0*DEG_2_RAD, 5.00E+0*DEG_2_RAD }}
+    @description: "MissionIntegralErrBdyLmt, sec"
+
+  .DeltaVIntegralErrBdyLmtBRE:
+    @datatype: uVector
+    @default: {{ 1.20E+1*DEG_2_RAD, 1.20E+1*DEG_2_RAD, 1.20E+1*DEG_2_RAD }}
+    @description: "DeltaVIntegralErrBdyLmtBRE, sec"
+
+  .DeltaVIntegralErrBdyLmtREA:
+    @datatype: uVector
+    @default: {{ 1.20E+1*DEG_2_RAD, 1.20E+1*DEG_2_RAD, 1.20E+1*DEG_2_RAD }}
+    @description: "DeltaVIntegralErrBdyLmtREA, sec"
+
+  .Cp[1][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Cp[1][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Cp[1][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Cp[2][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Deploying"
+
+  .Cp[2][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Deploying"
+
+  .Cp[2][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Deploying"
+
+  .Cp[3][1]:
+    @datatype: uVector
+    @default: { { 6.1685E-3, 6.1685E-3, 6.1685E-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[3][2]:
+    @datatype: uVector
+    @default: { { 6.1685E-3, 6.1685E-3, 6.1685E-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[3][3]:
+    @datatype: uVector
+    @default: { { 6.1685E-3, 6.1685E-3, 6.1685E-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[4][1]:
+    @datatype: uVector
+    @default: { { 6.1685E-3, 6.1685E-3, 6.1685E-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[4][2]:
+    @datatype: uVector
+    @default: { { 6.1685E-3, 6.1685E-3, 6.1685E-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[4][3]:
+    @datatype: uVector
+    @default: { { 6.1685E-3, 6.1685E-3, 6.1685E-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[5][1]:
+    @datatype: uVector
+    @default: { { 5.5630E-2, 5.5630E-2, 5.5630E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[5][2]:
+    @datatype: uVector
+    @default: { { 5.5630E-2, 5.5630E-2, 5.5630E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[5][3]:
+    @datatype: uVector
+    @default: { { 5.5630E-2, 5.5630E-2, 5.5630E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[6][1]:
+    @datatype: uVector
+    @default: { { 1.3907E-2, 1.3907E-2, 1.3907E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[6][2]:
+    @datatype: uVector
+    @default: { { 1.3907E-2, 1.3907E-2, 1.3907E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[6][3]:
+    @datatype: uVector
+    @default: { { 1.3907E-2, 1.3907E-2, 1.3907E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[7][1]:
+    @datatype: uVector
+    @default: { { 5.9522E-2, 5.9522E-2, 5.9522E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[7][2]:
+    @datatype: uVector
+    @default: { { 5.9522E-2, 5.9522E-2, 5.9522E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[7][3]:
+    @datatype: uVector
+    @default: { { 5.9522E-2, 5.9522E-2, 5.9522E-2 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[8][1]:
+    @datatype: uVector
+    @default: { { 1.4522e-3, 1.4522e-3, 1.4522e-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[8][2]:
+    @datatype: uVector
+    @default: { { 1.4522e-3, 1.4522e-3, 1.4522e-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cp[8][3]:
+    @datatype: uVector
+    @default: { { 1.4522e-3, 1.4522e-3, 1.4522e-3 } }
+    @description: "Mission .... Deployed --- Rate Control Gains, 1/sec ..."
+
+  .Cr[1][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Cr[1][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Cr[1][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Cr[2][1]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Standby ... Deploying"
+
+  .Cr[2][2]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Standby ... Deploying"
+
+  .Cr[2][3]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Standby ... Deploying"
+
+  .Cr[3][1]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[3][2]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[3][3]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[4][1]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[4][2]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[4][3]:
+    @datatype: uVector
+    @default: { { 1.1107E-1, 1.1107E-1, 1.1107E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[5][1]:
+    @datatype: uVector
+    @default: { { 3.4197E-1, 3.4197E-1, 3.4197E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[5][2]:
+    @datatype: uVector
+    @default: { { 3.4197E-1, 3.4197E-1, 3.4197E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[5][3]:
+    @datatype: uVector
+    @default: { { 3.4197E-1, 3.4197E-1, 3.4197E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[6][1]:
+    @datatype: uVector
+    @default: { { 1.7099E-1, 1.7099E-1, 1.7099E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[6][2]:
+    @datatype: uVector
+    @default: { { 1.7099E-1, 1.7099E-1, 1.7099E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[6][3]:
+    @datatype: uVector
+    @default: { { 1.7099E-1, 1.7099E-1, 1.7099E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[7][1]:
+    @datatype: uVector
+    @default: { { 3.5657E-1, 3.5657E-1, 3.5657E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[7][2]:
+    @datatype: uVector
+    @default: { { 3.5657E-1, 3.5657E-1, 3.5657E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[7][3]:
+    @datatype: uVector
+    @default: { { 3.5657E-1, 3.5657E-1, 3.5657E-1 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[8][1]:
+    @datatype: uVector
+    @default: { { 5.4901e-2, 5.4901e-2, 5.4901e-2 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[8][2]:
+    @datatype: uVector
+    @default: { { 5.4901e-2, 5.4901e-2, 5.4901e-2 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Cr[8][3]:
+    @datatype: uVector
+    @default: { { 5.4901e-2, 5.4901e-2, 5.4901e-2 } }
+    @description: "Mission .... Deployed --- Integral Control Gains, 1/sec^3 ..."
+
+  .Ci[1][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Ci[1][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Ci[1][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Stowed"
+
+  .Ci[2][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Deploying"
+
+  .Ci[2][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Deploying"
+
+  .Ci[2][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Standby ... Deploying"
+
+  .Ci[3][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[3][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[3][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[4][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[4][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[4][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[5][1]:
+    @datatype: uVector
+    @default: { { 2.6789E-3, 2.6789E-3, 2.6789E-3 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[5][2]:
+    @datatype: uVector
+    @default: { { 2.6789E-3, 2.6789E-3, 2.6789E-3 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[5][3]:
+    @datatype: uVector
+    @default: { { 2.6789E-3, 2.6789E-3, 2.6789E-3 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[6][1]:
+    @datatype: uVector
+    @default: { { 3.3487E-4, 3.3487E-4, 3.3487E-4 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[6][2]:
+    @datatype: uVector
+    @default: { { 3.3487E-4, 3.3487E-4, 3.3487E-4 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[6][3]:
+    @datatype: uVector
+    @default: { { 3.3487E-4, 3.3487E-4, 3.3487E-4 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[7][1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[7][2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[7][3]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 0.0 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[8][1]:
+    @datatype: uVector
+    @default: { { 1.0335e-5, 1.0335e-5, 1.0335e-5 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[8][2]:
+    @datatype: uVector
+    @default: { { 1.0335e-5, 1.0335e-5, 1.0335e-5 } }
+    @description: "Mission .... Deployed"
+
+  .Ci[8][3]:
+    @datatype: uVector
+    @default: { { 1.0335e-5, 1.0335e-5, 1.0335e-5 } }
+    @description: "Mission .... Deployed"
+
+  .ThetaErrHardThr:
+    @datatype: uVector
+    @default: {{ 5.00*DEG_2_RAD, 5.00*DEG_2_RAD, 5.00*DEG_2_RAD }}
+    @description: "--- Mission ... ThetaErrHardThr, rad"
+
+  .ThetaErrSoftThr:
+    @datatype: uVector
+    @default: {{ 4.09*DEG_2_RAD, 4.09*DEG_2_RAD, 4.09*DEG_2_RAD }}
+    @description: "ThetaErrSoftThr, rad"
+
+  .OmegaErrHardThr:
+    @datatype: uVector
+    @default: {{ 0.86*DEG_2_RAD, 0.86*DEG_2_RAD, 0.86*DEG_2_RAD }}
+    @description: "OmegaErrHardThr, rad/sec"
+
+  .OmegaErrSoftThr:
+    @datatype: uVector
+    @default: {{ 0.57*DEG_2_RAD, 0.57*DEG_2_RAD, 0.57*DEG_2_RAD }}
+    @description: "OmegaErrSoftThr, rad/sec"
+
+  .ThetaErrHardCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "ThetaErrHardCnt, cnt"
+
+  .ThetaErrSoftCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "ThetaErrSoftCnt, cnt"
+
+  .OmegaErrHardCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "OmegaErrHardCnt, cnt"
+
+  .OmegaErrSoftCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "OmegaErrSoftCnt, cnt"
+
+  .StaXResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaXResidualThr, rad"
+
+  .StaYResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaYResidualThr, rad"
+
+  .StaZResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaZResidualThr, rad"
+
+  .DeltaSysMomThr:
+    @datatype: dReal
+    @default: 1.5
+    @description: "DeltaSysMomThr, N-m-s"
+
+  .ResidualTestCnt:
+    @datatype: uWord
+    @default: 300*NUM_AC_CYCLES
+    @description: "ResidualTestCnt, cnt"
+
+  .DeltaSysMomCnt:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaSysMomCnt, cnt"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .ThetaErrHardThr:
+    @datatype: uVector
+    @default: {{ 1.00*DEG_2_RAD, 1.00*DEG_2_RAD, 1.00*DEG_2_RAD }}
+    @description: "--- Mission ... ThetaErrHardThr, rad"
+
+  .ThetaErrSoftThr:
+    @datatype: uVector
+    @default: {{ 0.50*DEG_2_RAD, 0.50*DEG_2_RAD, 0.50*DEG_2_RAD }}
+    @description: "ThetaErrSoftThr, rad"
+
+  .OmegaErrHardThr:
+    @datatype: uVector
+    @default: {{ 0.18*DEG_2_RAD, 0.18*DEG_2_RAD, 0.18*DEG_2_RAD }}
+    @description: "OmegaErrHardThr, rad/sec"
+
+  .OmegaErrSoftThr:
+    @datatype: uVector
+    @default: {{ 0.09*DEG_2_RAD, 0.09*DEG_2_RAD, 0.09*DEG_2_RAD }}
+    @description: "OmegaErrSoftThr, rad/sec"
+
+  .ThetaErrHardCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrHardCnt, cnt"
+
+  .ThetaErrSoftCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrSoftCnt, cnt"
+
+  .OmegaErrHardCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrHardCnt, cnt"
+
+  .OmegaErrSoftCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrSoftCnt, cnt"
+
+  .StaXResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaXResidualThr, rad"
+
+  .StaYResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaYResidualThr, rad"
+
+  .StaZResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaZResidualThr, rad"
+
+  .DeltaSysMomThr:
+    @datatype: dReal
+    @default: 1.5
+    @description: "DeltaSysMomThr, N-m-s"
+
+  .ResidualTestCnt:
+    @datatype: uWord
+    @default: 300*NUM_AC_CYCLES
+    @description: "ResidualTestCnt, cnt"
+
+  .DeltaSysMomCnt:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaSysMomCnt, cnt"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .ThetaErrHardThr:
+    @datatype: uVector
+    @default: {{ 1.00*DEG_2_RAD, 1.00*DEG_2_RAD, 1.00*DEG_2_RAD }}
+    @description: "--- Mission ... ThetaErrHardThr, rad"
+
+  .ThetaErrSoftThr:
+    @datatype: uVector
+    @default: {{ 0.50*DEG_2_RAD, 0.50*DEG_2_RAD, 0.50*DEG_2_RAD }}
+    @description: "ThetaErrSoftThr, rad"
+
+  .OmegaErrHardThr:
+    @datatype: uVector
+    @default: {{ 0.18*DEG_2_RAD, 0.18*DEG_2_RAD, 0.18*DEG_2_RAD }}
+    @description: "OmegaErrHardThr, rad/sec"
+
+  .OmegaErrSoftThr:
+    @datatype: uVector
+    @default: {{ 0.09*DEG_2_RAD, 0.09*DEG_2_RAD, 0.09*DEG_2_RAD }}
+    @description: "OmegaErrSoftThr, rad/sec"
+
+  .ThetaErrHardCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrHardCnt, cnt"
+
+  .ThetaErrSoftCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrSoftCnt, cnt"
+
+  .OmegaErrHardCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrHardCnt, cnt"
+
+  .OmegaErrSoftCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrSoftCnt, cnt"
+
+  .StaXResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaXResidualThr, rad"
+
+  .StaYResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaYResidualThr, rad"
+
+  .StaZResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaZResidualThr, rad"
+
+  .DeltaSysMomThr:
+    @datatype: dReal
+    @default: 1.5
+    @description: "DeltaSysMomThr, N-m-s"
+
+  .ResidualTestCnt:
+    @datatype: uWord
+    @default: 300*NUM_AC_CYCLES
+    @description: "ResidualTestCnt, cnt"
+
+  .DeltaSysMomCnt:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaSysMomCnt, cnt"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .ThetaErrHardThr:
+    @datatype: uVector
+    @default: {{ 15.00*DEG_2_RAD, 15.00*DEG_2_RAD, 45.00*DEG_2_RAD }}
+    @description: "--- Mission ... ThetaErrHardThr, rad"
+
+  .ThetaErrSoftThr:
+    @datatype: uVector
+    @default: {{ 10.00*DEG_2_RAD, 10.00*DEG_2_RAD, 30.00*DEG_2_RAD }}
+    @description: "ThetaErrSoftThr, rad"
+
+  .OmegaErrHardThrStationary:
+    @datatype: uVector
+    @default: {{ 0.15*DEG_2_RAD, 0.15*DEG_2_RAD, 0.15*DEG_2_RAD }}
+    @description: "OmegaErrHardThrStationary, rad/sec"
+
+  .OmegaErrSoftThrStationary:
+    @datatype: uVector
+    @default: {{ 0.10*DEG_2_RAD, 0.10*DEG_2_RAD, 0.10*DEG_2_RAD }}
+    @description: "OmegaErrSoftThrStationary, rad/sec"
+
+  .OmegaErrHardThrMoving:
+    @datatype: uVector
+    @default: {{ 0.45*DEG_2_RAD, 0.45*DEG_2_RAD, 1.50*DEG_2_RAD }}
+    @description: "OmegaErrHardThrMoving, rad/sec"
+
+  .OmegaErrSoftThrMoving:
+    @datatype: uVector
+    @default: {{ 0.30*DEG_2_RAD, 0.30*DEG_2_RAD, 1.00*DEG_2_RAD }}
+    @description: "OmegaErrSoftThrMoving, rad/sec"
+
+  .ThetaErrHardCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrHardCnt, cnt"
+
+  .ThetaErrSoftCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrSoftCnt, cnt"
+
+  .OmegaErrHardCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrHardCnt, cnt"
+
+  .OmegaErrSoftCnt:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrSoftCnt, cnt"
+
+  .StaXResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaXResidualThr, rad"
+
+  .StaYResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaYResidualThr, rad"
+
+  .StaZResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaZResidualThr, rad"
+
+  .DeltaSysMomThr:
+    @datatype: dReal
+    @default: 1.5
+    @description: "DeltaSysMomThr, N-m-s"
+
+  .ResidualTestCnt:
+    @datatype: uWord
+    @default: 300*NUM_AC_CYCLES
+    @description: "ResidualTestCnt, cnt"
+
+  .DeltaSysMomCnt:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaSysMomCnt, cnt"
+
+  .MplSlewingState[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "MplSlewingState [True/False ] PD_FAULT"
+
+  .MplSlewingState[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_IDLE"
+
+  .MplSlewingState[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_HOLD"
+
+  .MplSlewingState[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_SLEWING"
+
+  .MplSlewingState[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_TRACKING"
+
+  .MplSlewingState[6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_DECELERATE"
+
+  .MplSlewingState[7]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_TRACK_TABLE"
+
+  .MplSlewingState[8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_COMM_ANGLE"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .ThetaErrHardThrBRE:
+    @datatype: uVector
+    @default: {{ 4.00*DEG_2_RAD, 4.00*DEG_2_RAD, 4.00*DEG_2_RAD }}
+    @description: "--- DeltaV ... ThetaErrHardThrBRE, rad"
+
+  .ThetaErrSoftThrBRE:
+    @datatype: uVector
+    @default: {{ 2.00*DEG_2_RAD, 2.00*DEG_2_RAD, 2.00*DEG_2_RAD }}
+    @description: "ThetaErrSoftThrBRE, rad"
+
+  .OmegaErrHardThrBRE:
+    @datatype: uVector
+    @default: {{ 0.50*DEG_2_RAD, 0.50*DEG_2_RAD, 0.50*DEG_2_RAD }}
+    @description: "OmegaErrHardThrBRE, rad/sec"
+
+  .OmegaErrSoftThrBRE:
+    @datatype: uVector
+    @default: {{ 0.20*DEG_2_RAD, 0.20*DEG_2_RAD, 0.20*DEG_2_RAD }}
+    @description: "OmegaErrSoftThrBRE, rad/sec"
+
+  .ThetaErrHardCntBRE:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrHardCntBRE, cnt"
+
+  .ThetaErrSoftCntBRE:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "ThetaErrSoftCntBRE, cnt"
+
+  .OmegaErrHardCntBRE:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrHardCntBRE, cnt"
+
+  .OmegaErrSoftCntBRE:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "OmegaErrSoftCntBRE, cnt"
+
+  .ThetaErrHardThrREA:
+    @datatype: uVector
+    @default: {{ 5.00*DEG_2_RAD, 5.00*DEG_2_RAD, 5.00*DEG_2_RAD }}
+    @description: "ThetaErrHardThrREA, rad"
+
+  .ThetaErrSoftThrREA:
+    @datatype: uVector
+    @default: {{ 4.00*DEG_2_RAD, 4.00*DEG_2_RAD, 4.00*DEG_2_RAD }}
+    @description: "ThetaErrSoftThrREA, rad"
+
+  .OmegaErrHardThrREA:
+    @datatype: uVector
+    @default: {{ 1.00*DEG_2_RAD, 1.00*DEG_2_RAD, 1.00*DEG_2_RAD }}
+    @description: "OmegaErrHardThrREA, rad/sec"
+
+  .OmegaErrSoftThrREA:
+    @datatype: uVector
+    @default: {{ 1.00*DEG_2_RAD, 1.00*DEG_2_RAD, 1.00*DEG_2_RAD }}
+    @description: "OmegaErrSoftThrREA, rad/sec"
+
+  .ThetaErrHardCntREA:
+    @datatype: uWord
+    @default: 4*NUM_AC_CYCLES
+    @description: "ThetaErrHardCntREA, cnt"
+
+  .ThetaErrSoftCntREA:
+    @datatype: uWord
+    @default: 4*NUM_AC_CYCLES
+    @description: "ThetaErrSoftCntREA, cnt"
+
+  .OmegaErrHardCntREA:
+    @datatype: uWord
+    @default: 4*NUM_AC_CYCLES
+    @description: "OmegaErrHardCntREA, cnt"
+
+  .OmegaErrSoftCntREA:
+    @datatype: uWord
+    @default: 4*NUM_AC_CYCLES
+    @description: "OmegaErrSoftCntREA, cnt"
+
+  .StaXResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaXResidualThr, rad"
+
+  .StaYResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaYResidualThr, rad"
+
+  .StaZResidualThr:
+    @datatype: dReal
+    @default: 0.40*DEG_2_RAD
+    @description: "StaZResidualThr, rad"
+
+  .DeltaSysMomThr:
+    @datatype: dReal
+    @default: 4
+    @description: "DeltaSysMomThr, N-m-s"
+
+  .ResidualTestCnt:
+    @datatype: uWord
+    @default: 300*NUM_AC_CYCLES
+    @description: "ResidualTestCnt, cnt"
+
+  .DeltaSysMomCnt:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaSysMomCnt, cnt"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+}
+
+table ac_css_table_type {
+  @buildstruct!
+  .AtoDGainFactor[1][1]:
+    @datatype: dReal
+    @default: 3.1810
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=1)"
+
+  .AtoDGainFactor[1][2]:
+    @datatype: dReal
+    @default: 2.8390
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=1)"
+
+  .AtoDGainFactor[2][1]:
+    @datatype: dReal
+    @default: 2.9697
+    @description: "CSS #2 (SV_ID=1)"
+
+  .AtoDGainFactor[2][2]:
+    @datatype: dReal
+    @default: 3.0503
+    @description: "CSS #2 (SV_ID=1)"
+
+  .AtoDGainFactor[3][1]:
+    @datatype: dReal
+    @default: 3.1770
+    @description: "CSS #3 (SV_ID=1)"
+
+  .AtoDGainFactor[3][2]:
+    @datatype: dReal
+    @default: 2.8430
+    @description: "CSS #3 (SV_ID=1)"
+
+  .AtoDGainFactor[4][1]:
+    @datatype: dReal
+    @default: 2.9708
+    @description: "CSS #4 (SV_ID=1)"
+
+  .AtoDGainFactor[4][2]:
+    @datatype: dReal
+    @default: 3.0492
+    @description: "CSS #4 (SV_ID=1)"
+
+  .AtoDGainFactor[5][1]:
+    @datatype: dReal
+    @default: 3.1802
+    @description: "CSS #5 (SV_ID=1)"
+
+  .AtoDGainFactor[5][2]:
+    @datatype: dReal
+    @default: 2.8398
+    @description: "CSS #5 (SV_ID=1)"
+
+  .AtoDGainFactor[6][1]:
+    @datatype: dReal
+    @default: 2.9689
+    @description: "CSS #6 (SV_ID=1)"
+
+  .AtoDGainFactor[6][2]:
+    @datatype: dReal
+    @default: 3.0511
+    @description: "CSS #6 (SV_ID=1)"
+
+  .AtoDGainFactor[7][1]:
+    @datatype: dReal
+    @default: 3.1838
+    @description: "CSS #7 (SV_ID=1)"
+
+  .AtoDGainFactor[7][2]:
+    @datatype: dReal
+    @default: 2.8362
+    @description: "CSS #7 (SV_ID=1)"
+
+  .AtoDGainFactor[8][1]:
+    @datatype: dReal
+    @default: 2.9677
+    @description: "CSS #8 (SV_ID=1)"
+
+  .AtoDGainFactor[8][2]:
+    @datatype: dReal
+    @default: 3.0523
+    @description: "CSS #8 (SV_ID=1)"
+
+  .AtoDGainFactor[9][1]:
+    @datatype: dReal
+    @default: 2.9451
+    @description: "CSS #9 (SV_ID=1)"
+
+  .AtoDGainFactor[9][2]:
+    @datatype: dReal
+    @default: 3.0749
+    @description: "CSS #9 (SV_ID=1)"
+
+  .AtoDGainFactor[10][1]:
+    @datatype: dReal
+    @default: 2.9494
+    @description: "CSS #10 (SV_ID=1)"
+
+  .AtoDGainFactor[10][2]:
+    @datatype: dReal
+    @default: 3.0706
+    @description: "CSS #10 (SV_ID=1)"
+
+  .AtoDGainFactor[11][1]:
+    @datatype: dReal
+    @default: 2.9971
+    @description: "CSS #11 (SV_ID=1)"
+
+  .AtoDGainFactor[11][2]:
+    @datatype: dReal
+    @default: 3.0229
+    @description: "CSS #11 (SV_ID=1)"
+
+  .AtoDGainFactor[12][1]:
+    @datatype: dReal
+    @default: 2.9973
+    @description: "CSS #12 (SV_ID=1)"
+
+  .AtoDGainFactor[12][2]:
+    @datatype: dReal
+    @default: 3.0227
+    @description: "CSS #12 (SV_ID=1)"
+
+  .AtoDGainFactor[13][1]:
+    @datatype: dReal
+    @default: 2.9420
+    @description: "CSS #13 (SV_ID=1)"
+
+  .AtoDGainFactor[13][2]:
+    @datatype: dReal
+    @default: 3.0780
+    @description: "CSS #13 (SV_ID=1)"
+
+  .AtoDGainFactor[14][1]:
+    @datatype: dReal
+    @default: 2.9392
+    @description: "CSS #14 (SV_ID=1)"
+
+  .AtoDGainFactor[14][2]:
+    @datatype: dReal
+    @default: 3.0808
+    @description: "CSS #14 (SV_ID=1)"
+
+  .AtoDGainFactor[15][1]:
+    @datatype: dReal
+    @default: 2.9940
+    @description: "CSS #15 (SV_ID=1)"
+
+  .AtoDGainFactor[15][2]:
+    @datatype: dReal
+    @default: 3.0260
+    @description: "CSS #15 (SV_ID=1)"
+
+  .AtoDGainFactor[16][1]:
+    @datatype: dReal
+    @default: 2.9939
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AtoDGainFactor[16][2]:
+    @datatype: dReal
+    @default: 3.0261
+    @description: "CSS #16 (SV_ID=1)"
+
+  .ScaleFactor:
+    @datatype: dReal
+    @default: 40.08
+    @description: "ScaleFactor (SV_ID=1)"
+
+  .RateCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "RateCycleMask, Calculate CSS Derived Rate Vector Cycle Mask (1 Hz) (SV_ID=1)"
+
+  .RateFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "RateFrameMask, Calculate CSS Derived Rate Vector Frame Mask, Every Frame 1 - 15 (SV_ID=1)"
+
+  .Spare1[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=1)"
+
+  .Spare1[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=1)"
+
+  .SdotFiltera1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFiltera1 (SV_ID=1)"
+
+  .SdotFilterb1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFilterb1 (SV_ID=1)"
+
+  .CoplanarLimit:
+    @datatype: dReal
+    @default: 5.0*DEG_2_RAD
+    @description: "CoplanarLimit (SV_ID=1)"
+
+  .AlbedoThr[1]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.37 * 0.069) Looking +Z in Stowed Configuration (SV_ID=1)"
+
+  .AlbedoThr[2]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.30 * 0.069) Otherwise (SV_ID=1)"
+
+  .AlbedoThr[3]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[4]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[5]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[6]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[7]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[8]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[9]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[10]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[11]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[12]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[13]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[14]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[15]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=1)"
+
+  .AlbedoThr[16]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=1)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=1)"
+
+  .MinDetectorCurrent[1]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "MinDetectorCurrent, Amp (SV_ID=1)"
+
+  .MinDetectorCurrent[2]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[3]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[4]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[5]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[6]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[7]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[8]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[9]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[10]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[11]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[12]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[13]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[14]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[15]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .MinDetectorCurrent[16]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=1)"
+
+  .CssBoresightBdy0[1][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=1)"
+
+  .CssBoresightBdy0[1][2]:
+    @datatype: uVector
+    @default: { { 0.002, 0.052, 0.102 } }
+    @description: "CSS#1 .... Stowed (SV_ID=1)"
+
+  .CssBoresightBdy0[1][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=1)"
+
+  .CssBoresightBdy0[2][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=1)"
+
+  .CssBoresightBdy0[2][2]:
+    @datatype: uVector
+    @default: { { 0.005, 0.055, 0.105 } }
+    @description: "CSS#1 .... Deploying (SV_ID=1)"
+
+  .CssBoresightBdy0[2][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=1)"
+
+  .CssBoresightBdy0[3][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[3][2]:
+    @datatype: uVector
+    @default: { { 0.008, 0.058, 0.108 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[3][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[4][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[4][2]:
+    @datatype: uVector
+    @default: { { 0.011, 0.061, 0.111 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[4][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[5][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[5][2]:
+    @datatype: uVector
+    @default: { { 0.014, 0.064, 0.114 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[5][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[6][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[6][2]:
+    @datatype: uVector
+    @default: { { 0.017, 0.067, 0.117 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[6][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[7][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[7][2]:
+    @datatype: uVector
+    @default: { { 0.020, 0.070, 0.120 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[7][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[8][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[8][2]:
+    @datatype: uVector
+    @default: { { 0.023, 0.073, 0.123 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[8][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[9][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[9][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[9][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[10][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[10][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[10][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[11][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[11][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[11][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[12][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[12][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[12][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[13][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[13][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[13][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[14][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[14][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[14][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[15][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[15][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[15][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[16][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[16][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .CssBoresightBdy0[16][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=1)"
+
+  .FailTimeOut:
+    @datatype: uWord
+    @default: 6 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "FailTimeOut, cycles (SV_ID=1)"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (SV_ID=1)"
+
+  .EndEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "EndEclipseCount (SV_ID=1)"
+
+  .MaxEclipseDuration[1]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "MaxEclipseDuration (72 min.) Stowed (SV_ID=1)"
+
+  .MaxEclipseDuration[2]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deploying (SV_ID=1)"
+
+  .MaxEclipseDuration[3]:
+    @datatype: uWord
+    @default: 72 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deployed (SV_ID=1)"
+
+  .Spare2[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=1)"
+
+  .Spare2[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=1)"
+
+  .EnableRiu2Tlm[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[9]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[10]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[11]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[12]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[13]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[14]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[15]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .EnableRiu2Tlm[16]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=1)"
+
+  .CssLocation[1]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[2]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[3]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[4]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[5]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[6]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[7]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[8]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[9]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[10]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[11]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[12]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[13]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[14]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[15]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .CssLocation[16]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=1)"
+
+  .AllowCSS[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[3][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[4][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[4][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[5][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[6][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[7][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[7][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[8][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[8][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[9][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[9][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[9][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[10][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[10][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[10][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[11][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[11][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[11][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[12][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[12][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[12][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[13][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[13][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[13][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[14][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[14][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[14][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[15][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[15][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[15][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[16][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[16][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .AllowCSS[16][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=1)"
+
+  .CurrentTestCnt[1]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[2]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[3]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[4]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[5]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[6]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[7]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[8]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[9]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[10]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[11]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[12]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[13]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[14]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[15]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .CurrentTestCnt[16]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=1)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=1)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=1)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=1)"
+
+  .AtoDGainFactor[1][1]:
+    @datatype: dReal
+    @default: 3.1986
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=2)"
+
+  .AtoDGainFactor[1][2]:
+    @datatype: dReal
+    @default: 2.8214
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=2)"
+
+  .AtoDGainFactor[2][1]:
+    @datatype: dReal
+    @default: 2.9654
+    @description: "CSS #2 (SV_ID=2)"
+
+  .AtoDGainFactor[2][2]:
+    @datatype: dReal
+    @default: 3.0546
+    @description: "CSS #2 (SV_ID=2)"
+
+  .AtoDGainFactor[3][1]:
+    @datatype: dReal
+    @default: 3.1954
+    @description: "CSS #3 (SV_ID=2)"
+
+  .AtoDGainFactor[3][2]:
+    @datatype: dReal
+    @default: 2.8246
+    @description: "CSS #3 (SV_ID=2)"
+
+  .AtoDGainFactor[4][1]:
+    @datatype: dReal
+    @default: 2.9648
+    @description: "CSS #4 (SV_ID=2)"
+
+  .AtoDGainFactor[4][2]:
+    @datatype: dReal
+    @default: 3.0552
+    @description: "CSS #4 (SV_ID=2)"
+
+  .AtoDGainFactor[5][1]:
+    @datatype: dReal
+    @default: 3.1973
+    @description: "CSS #5 (SV_ID=2)"
+
+  .AtoDGainFactor[5][2]:
+    @datatype: dReal
+    @default: 2.8227
+    @description: "CSS #5 (SV_ID=2)"
+
+  .AtoDGainFactor[6][1]:
+    @datatype: dReal
+    @default: 2.9572
+    @description: "CSS #6 (SV_ID=2)"
+
+  .AtoDGainFactor[6][2]:
+    @datatype: dReal
+    @default: 3.0628
+    @description: "CSS #6 (SV_ID=2)"
+
+  .AtoDGainFactor[7][1]:
+    @datatype: dReal
+    @default: 3.1949
+    @description: "CSS #7 (SV_ID=2)"
+
+  .AtoDGainFactor[7][2]:
+    @datatype: dReal
+    @default: 2.8251
+    @description: "CSS #7 (SV_ID=2)"
+
+  .AtoDGainFactor[8][1]:
+    @datatype: dReal
+    @default: 2.9601
+    @description: "CSS #8 (SV_ID=2)"
+
+  .AtoDGainFactor[8][2]:
+    @datatype: dReal
+    @default: 3.0599
+    @description: "CSS #8 (SV_ID=2)"
+
+  .AtoDGainFactor[9][1]:
+    @datatype: dReal
+    @default: 2.9460
+    @description: "CSS #9 (SV_ID=2)"
+
+  .AtoDGainFactor[9][2]:
+    @datatype: dReal
+    @default: 3.0740
+    @description: "CSS #9 (SV_ID=2)"
+
+  .AtoDGainFactor[10][1]:
+    @datatype: dReal
+    @default: 2.9447
+    @description: "CSS #10 (SV_ID=2)"
+
+  .AtoDGainFactor[10][2]:
+    @datatype: dReal
+    @default: 3.0753
+    @description: "CSS #10 (SV_ID=2)"
+
+  .AtoDGainFactor[11][1]:
+    @datatype: dReal
+    @default: 3.0021
+    @description: "CSS #11 (SV_ID=2)"
+
+  .AtoDGainFactor[11][2]:
+    @datatype: dReal
+    @default: 3.0179
+    @description: "CSS #11 (SV_ID=2)"
+
+  .AtoDGainFactor[12][1]:
+    @datatype: dReal
+    @default: 3.0029
+    @description: "CSS #12 (SV_ID=2)"
+
+  .AtoDGainFactor[12][2]:
+    @datatype: dReal
+    @default: 3.0171
+    @description: "CSS #12 (SV_ID=2)"
+
+  .AtoDGainFactor[13][1]:
+    @datatype: dReal
+    @default: 2.9439
+    @description: "CSS #13 (SV_ID=2)"
+
+  .AtoDGainFactor[13][2]:
+    @datatype: dReal
+    @default: 3.0761
+    @description: "CSS #13 (SV_ID=2)"
+
+  .AtoDGainFactor[14][1]:
+    @datatype: dReal
+    @default: 2.9462
+    @description: "CSS #14 (SV_ID=2)"
+
+  .AtoDGainFactor[14][2]:
+    @datatype: dReal
+    @default: 3.0738
+    @description: "CSS #14 (SV_ID=2)"
+
+  .AtoDGainFactor[15][1]:
+    @datatype: dReal
+    @default: 3.0032
+    @description: "CSS #15 (SV_ID=2)"
+
+  .AtoDGainFactor[15][2]:
+    @datatype: dReal
+    @default: 3.0168
+    @description: "CSS #15 (SV_ID=2)"
+
+  .AtoDGainFactor[16][1]:
+    @datatype: dReal
+    @default: 3.0039
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AtoDGainFactor[16][2]:
+    @datatype: dReal
+    @default: 3.0161
+    @description: "CSS #16 (SV_ID=2)"
+
+  .ScaleFactor:
+    @datatype: dReal
+    @default: 40.08
+    @description: "ScaleFactor (SV_ID=2)"
+
+  .RateCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "RateCycleMask, Calculate CSS Derived Rate Vector Cycle Mask (1 Hz) (SV_ID=2)"
+
+  .RateFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "RateFrameMask, Calculate CSS Derived Rate Vector Frame Mask, Every Frame 1 - 15 (SV_ID=2)"
+
+  .Spare1[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=2)"
+
+  .Spare1[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=2)"
+
+  .SdotFiltera1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFiltera1 (SV_ID=2)"
+
+  .SdotFilterb1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFilterb1 (SV_ID=2)"
+
+  .CoplanarLimit:
+    @datatype: dReal
+    @default: 5.0*DEG_2_RAD
+    @description: "CoplanarLimit (SV_ID=2)"
+
+  .AlbedoThr[1]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.37 * 0.069) Looking +Z in Stowed Configuration (SV_ID=2)"
+
+  .AlbedoThr[2]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.30 * 0.069) Otherwise (SV_ID=2)"
+
+  .AlbedoThr[3]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[4]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[5]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[6]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[7]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[8]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[9]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[10]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[11]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[12]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[13]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[14]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[15]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=2)"
+
+  .AlbedoThr[16]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=2)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=2)"
+
+  .MinDetectorCurrent[1]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "MinDetectorCurrent, Amp (SV_ID=2)"
+
+  .MinDetectorCurrent[2]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[3]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[4]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[5]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[6]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[7]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[8]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[9]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[10]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[11]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[12]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[13]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[14]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[15]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .MinDetectorCurrent[16]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=2)"
+
+  .CssBoresightBdy0[1][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=2)"
+
+  .CssBoresightBdy0[1][2]:
+    @datatype: uVector
+    @default: { { 0.002, 0.052, 0.102 } }
+    @description: "CSS#1 .... Stowed (SV_ID=2)"
+
+  .CssBoresightBdy0[1][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=2)"
+
+  .CssBoresightBdy0[2][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=2)"
+
+  .CssBoresightBdy0[2][2]:
+    @datatype: uVector
+    @default: { { 0.005, 0.055, 0.105 } }
+    @description: "CSS#1 .... Deploying (SV_ID=2)"
+
+  .CssBoresightBdy0[2][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=2)"
+
+  .CssBoresightBdy0[3][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[3][2]:
+    @datatype: uVector
+    @default: { { 0.008, 0.058, 0.108 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[3][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[4][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[4][2]:
+    @datatype: uVector
+    @default: { { 0.011, 0.061, 0.111 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[4][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[5][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[5][2]:
+    @datatype: uVector
+    @default: { { 0.014, 0.064, 0.114 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[5][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[6][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[6][2]:
+    @datatype: uVector
+    @default: { { 0.017, 0.067, 0.117 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[6][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[7][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[7][2]:
+    @datatype: uVector
+    @default: { { 0.020, 0.070, 0.120 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[7][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[8][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[8][2]:
+    @datatype: uVector
+    @default: { { 0.023, 0.073, 0.123 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[8][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[9][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[9][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[9][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[10][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[10][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[10][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[11][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[11][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[11][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[12][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[12][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[12][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[13][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[13][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[13][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[14][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[14][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[14][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[15][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[15][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[15][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[16][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[16][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .CssBoresightBdy0[16][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=2)"
+
+  .FailTimeOut:
+    @datatype: uWord
+    @default: 6 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "FailTimeOut, cycles (SV_ID=2)"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (SV_ID=2)"
+
+  .EndEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "EndEclipseCount (SV_ID=2)"
+
+  .MaxEclipseDuration[1]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "MaxEclipseDuration (72 min.) Stowed (SV_ID=2)"
+
+  .MaxEclipseDuration[2]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deploying (SV_ID=2)"
+
+  .MaxEclipseDuration[3]:
+    @datatype: uWord
+    @default: 72 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deployed (SV_ID=2)"
+
+  .Spare2[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=2)"
+
+  .Spare2[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=2)"
+
+  .EnableRiu2Tlm[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[9]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[10]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[11]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[12]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[13]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[14]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[15]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .EnableRiu2Tlm[16]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=2)"
+
+  .CssLocation[1]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[2]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[3]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[4]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[5]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[6]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[7]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[8]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[9]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[10]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[11]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[12]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[13]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[14]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[15]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .CssLocation[16]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=2)"
+
+  .AllowCSS[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[3][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[4][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[4][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[5][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[6][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[7][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[7][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[8][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[8][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[9][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[9][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[9][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[10][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[10][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[10][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[11][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[11][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[11][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[12][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[12][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[12][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[13][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[13][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[13][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[14][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[14][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[14][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[15][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[15][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[15][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[16][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[16][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .AllowCSS[16][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=2)"
+
+  .CurrentTestCnt[1]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[2]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[3]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[4]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[5]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[6]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[7]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[8]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[9]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[10]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[11]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[12]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[13]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[14]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[15]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .CurrentTestCnt[16]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=2)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=2)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=2)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=2)"
+
+  .AtoDGainFactor[1][1]:
+    @datatype: dReal
+    @default: 3.2005
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=3)"
+
+  .AtoDGainFactor[1][2]:
+    @datatype: dReal
+    @default: 2.8195
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=3)"
+
+  .AtoDGainFactor[2][1]:
+    @datatype: dReal
+    @default: 2.9806
+    @description: "CSS #2 (SV_ID=3)"
+
+  .AtoDGainFactor[2][2]:
+    @datatype: dReal
+    @default: 3.0394
+    @description: "CSS #2 (SV_ID=3)"
+
+  .AtoDGainFactor[3][1]:
+    @datatype: dReal
+    @default: 3.2005
+    @description: "CSS #3 (SV_ID=3)"
+
+  .AtoDGainFactor[3][2]:
+    @datatype: dReal
+    @default: 2.8195
+    @description: "CSS #3 (SV_ID=3)"
+
+  .AtoDGainFactor[4][1]:
+    @datatype: dReal
+    @default: 2.9819
+    @description: "CSS #4 (SV_ID=3)"
+
+  .AtoDGainFactor[4][2]:
+    @datatype: dReal
+    @default: 3.0381
+    @description: "CSS #4 (SV_ID=3)"
+
+  .AtoDGainFactor[5][1]:
+    @datatype: dReal
+    @default: 3.1992
+    @description: "CSS #5 (SV_ID=3)"
+
+  .AtoDGainFactor[5][2]:
+    @datatype: dReal
+    @default: 2.8208
+    @description: "CSS #5 (SV_ID=3)"
+
+  .AtoDGainFactor[6][1]:
+    @datatype: dReal
+    @default: 2.9787
+    @description: "CSS #6 (SV_ID=3)"
+
+  .AtoDGainFactor[6][2]:
+    @datatype: dReal
+    @default: 3.0413
+    @description: "CSS #6 (SV_ID=3)"
+
+  .AtoDGainFactor[7][1]:
+    @datatype: dReal
+    @default: 3.2019
+    @description: "CSS #7 (SV_ID=3)"
+
+  .AtoDGainFactor[7][2]:
+    @datatype: dReal
+    @default: 2.8181
+    @description: "CSS #7 (SV_ID=3)"
+
+  .AtoDGainFactor[8][1]:
+    @datatype: dReal
+    @default: 2.9796
+    @description: "CSS #8 (SV_ID=3)"
+
+  .AtoDGainFactor[8][2]:
+    @datatype: dReal
+    @default: 3.0404
+    @description: "CSS #8 (SV_ID=3)"
+
+  .AtoDGainFactor[9][1]:
+    @datatype: dReal
+    @default: 2.9478
+    @description: "CSS #9 (SV_ID=3)"
+
+  .AtoDGainFactor[9][2]:
+    @datatype: dReal
+    @default: 3.0722
+    @description: "CSS #9 (SV_ID=3)"
+
+  .AtoDGainFactor[10][1]:
+    @datatype: dReal
+    @default: 2.9491
+    @description: "CSS #10 (SV_ID=3)"
+
+  .AtoDGainFactor[10][2]:
+    @datatype: dReal
+    @default: 3.0709
+    @description: "CSS #10 (SV_ID=3)"
+
+  .AtoDGainFactor[11][1]:
+    @datatype: dReal
+    @default: 3.0095
+    @description: "CSS #11 (SV_ID=3)"
+
+  .AtoDGainFactor[11][2]:
+    @datatype: dReal
+    @default: 3.0105
+    @description: "CSS #11 (SV_ID=3)"
+
+  .AtoDGainFactor[12][1]:
+    @datatype: dReal
+    @default: 3.0120
+    @description: "CSS #12 (SV_ID=3)"
+
+  .AtoDGainFactor[12][2]:
+    @datatype: dReal
+    @default: 3.0080
+    @description: "CSS #12 (SV_ID=3)"
+
+  .AtoDGainFactor[13][1]:
+    @datatype: dReal
+    @default: 2.9486
+    @description: "CSS #13 (SV_ID=3)"
+
+  .AtoDGainFactor[13][2]:
+    @datatype: dReal
+    @default: 3.0714
+    @description: "CSS #13 (SV_ID=3)"
+
+  .AtoDGainFactor[14][1]:
+    @datatype: dReal
+    @default: 2.9485
+    @description: "CSS #14 (SV_ID=3)"
+
+  .AtoDGainFactor[14][2]:
+    @datatype: dReal
+    @default: 3.0715
+    @description: "CSS #14 (SV_ID=3)"
+
+  .AtoDGainFactor[15][1]:
+    @datatype: dReal
+    @default: 3.0075
+    @description: "CSS #15 (SV_ID=3)"
+
+  .AtoDGainFactor[15][2]:
+    @datatype: dReal
+    @default: 3.0125
+    @description: "CSS #15 (SV_ID=3)"
+
+  .AtoDGainFactor[16][1]:
+    @datatype: dReal
+    @default: 3.0120
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AtoDGainFactor[16][2]:
+    @datatype: dReal
+    @default: 3.0080
+    @description: "CSS #16 (SV_ID=3)"
+
+  .ScaleFactor:
+    @datatype: dReal
+    @default: 40.08
+    @description: "ScaleFactor (SV_ID=3)"
+
+  .RateCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "RateCycleMask, Calculate CSS Derived Rate Vector Cycle Mask (1 Hz) (SV_ID=3)"
+
+  .RateFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "RateFrameMask, Calculate CSS Derived Rate Vector Frame Mask, Every Frame 1 - 15 (SV_ID=3)"
+
+  .Spare1[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=3)"
+
+  .Spare1[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=3)"
+
+  .SdotFiltera1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFiltera1 (SV_ID=3)"
+
+  .SdotFilterb1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFilterb1 (SV_ID=3)"
+
+  .CoplanarLimit:
+    @datatype: dReal
+    @default: 5.0*DEG_2_RAD
+    @description: "CoplanarLimit (SV_ID=3)"
+
+  .AlbedoThr[1]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.37 * 0.069) Looking +Z in Stowed Configuration (SV_ID=3)"
+
+  .AlbedoThr[2]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.30 * 0.069) Otherwise (SV_ID=3)"
+
+  .AlbedoThr[3]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[4]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[5]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[6]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[7]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[8]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[9]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[10]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[11]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[12]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[13]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[14]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[15]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=3)"
+
+  .AlbedoThr[16]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=3)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=3)"
+
+  .MinDetectorCurrent[1]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "MinDetectorCurrent, Amp (SV_ID=3)"
+
+  .MinDetectorCurrent[2]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[3]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[4]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[5]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[6]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[7]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[8]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[9]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[10]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[11]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[12]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[13]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[14]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[15]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .MinDetectorCurrent[16]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=3)"
+
+  .CssBoresightBdy0[1][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=3)"
+
+  .CssBoresightBdy0[1][2]:
+    @datatype: uVector
+    @default: { { 0.002, 0.052, 0.102 } }
+    @description: "CSS#1 .... Stowed (SV_ID=3)"
+
+  .CssBoresightBdy0[1][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=3)"
+
+  .CssBoresightBdy0[2][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=3)"
+
+  .CssBoresightBdy0[2][2]:
+    @datatype: uVector
+    @default: { { 0.005, 0.055, 0.105 } }
+    @description: "CSS#1 .... Deploying (SV_ID=3)"
+
+  .CssBoresightBdy0[2][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=3)"
+
+  .CssBoresightBdy0[3][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[3][2]:
+    @datatype: uVector
+    @default: { { 0.008, 0.058, 0.108 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[3][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[4][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[4][2]:
+    @datatype: uVector
+    @default: { { 0.011, 0.061, 0.111 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[4][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[5][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[5][2]:
+    @datatype: uVector
+    @default: { { 0.014, 0.064, 0.114 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[5][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[6][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[6][2]:
+    @datatype: uVector
+    @default: { { 0.017, 0.067, 0.117 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[6][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[7][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[7][2]:
+    @datatype: uVector
+    @default: { { 0.020, 0.070, 0.120 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[7][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[8][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[8][2]:
+    @datatype: uVector
+    @default: { { 0.023, 0.073, 0.123 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[8][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[9][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[9][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[9][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[10][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[10][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[10][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[11][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[11][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[11][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[12][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[12][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[12][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[13][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[13][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[13][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[14][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[14][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[14][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[15][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[15][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[15][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[16][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[16][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .CssBoresightBdy0[16][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=3)"
+
+  .FailTimeOut:
+    @datatype: uWord
+    @default: 6 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "FailTimeOut, cycles (SV_ID=3)"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (SV_ID=3)"
+
+  .EndEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "EndEclipseCount (SV_ID=3)"
+
+  .MaxEclipseDuration[1]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "MaxEclipseDuration (72 min.) Stowed (SV_ID=3)"
+
+  .MaxEclipseDuration[2]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deploying (SV_ID=3)"
+
+  .MaxEclipseDuration[3]:
+    @datatype: uWord
+    @default: 72 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deployed (SV_ID=3)"
+
+  .Spare2[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=3)"
+
+  .Spare2[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=3)"
+
+  .EnableRiu2Tlm[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[9]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[10]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[11]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[12]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[13]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[14]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[15]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .EnableRiu2Tlm[16]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=3)"
+
+  .CssLocation[1]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[2]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[3]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[4]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[5]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[6]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[7]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[8]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[9]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[10]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[11]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[12]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[13]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[14]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[15]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .CssLocation[16]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=3)"
+
+  .AllowCSS[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[3][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[4][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[4][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[5][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[6][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[7][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[7][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[8][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[8][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[9][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[9][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[9][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[10][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[10][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[10][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[11][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[11][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[11][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[12][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[12][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[12][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[13][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[13][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[13][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[14][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[14][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[14][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[15][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[15][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[15][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[16][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[16][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .AllowCSS[16][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=3)"
+
+  .CurrentTestCnt[1]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[2]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[3]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[4]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[5]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[6]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[7]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[8]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[9]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[10]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[11]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[12]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[13]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[14]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[15]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .CurrentTestCnt[16]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=3)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=3)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=3)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=3)"
+
+  .AtoDGainFactor[1][1]:
+    @datatype: dReal
+    @default: 3.3205
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=4)"
+
+  .AtoDGainFactor[1][2]:
+    @datatype: dReal
+    @default: 2.6995
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=4)"
+
+  .AtoDGainFactor[2][1]:
+    @datatype: dReal
+    @default: 2.9892
+    @description: "CSS #2 (SV_ID=4)"
+
+  .AtoDGainFactor[2][2]:
+    @datatype: dReal
+    @default: 3.0308
+    @description: "CSS #2 (SV_ID=4)"
+
+  .AtoDGainFactor[3][1]:
+    @datatype: dReal
+    @default: 3.3186
+    @description: "CSS #3 (SV_ID=4)"
+
+  .AtoDGainFactor[3][2]:
+    @datatype: dReal
+    @default: 2.7014
+    @description: "CSS #3 (SV_ID=4)"
+
+  .AtoDGainFactor[4][1]:
+    @datatype: dReal
+    @default: 2.9872
+    @description: "CSS #4 (SV_ID=4)"
+
+  .AtoDGainFactor[4][2]:
+    @datatype: dReal
+    @default: 3.0328
+    @description: "CSS #4 (SV_ID=4)"
+
+  .AtoDGainFactor[5][1]:
+    @datatype: dReal
+    @default: 3.3208
+    @description: "CSS #5 (SV_ID=4)"
+
+  .AtoDGainFactor[5][2]:
+    @datatype: dReal
+    @default: 2.6992
+    @description: "CSS #5 (SV_ID=4)"
+
+  .AtoDGainFactor[6][1]:
+    @datatype: dReal
+    @default: 2.9867
+    @description: "CSS #6 (SV_ID=4)"
+
+  .AtoDGainFactor[6][2]:
+    @datatype: dReal
+    @default: 3.0333
+    @description: "CSS #6 (SV_ID=4)"
+
+  .AtoDGainFactor[7][1]:
+    @datatype: dReal
+    @default: 3.3234
+    @description: "CSS #7 (SV_ID=4)"
+
+  .AtoDGainFactor[7][2]:
+    @datatype: dReal
+    @default: 2.6966
+    @description: "CSS #7 (SV_ID=4)"
+
+  .AtoDGainFactor[8][1]:
+    @datatype: dReal
+    @default: 2.9875
+    @description: "CSS #8 (SV_ID=4)"
+
+  .AtoDGainFactor[8][2]:
+    @datatype: dReal
+    @default: 3.0325
+    @description: "CSS #8 (SV_ID=4)"
+
+  .AtoDGainFactor[9][1]:
+    @datatype: dReal
+    @default: 2.9956
+    @description: "CSS #9 (SV_ID=4)"
+
+  .AtoDGainFactor[9][2]:
+    @datatype: dReal
+    @default: 3.0244
+    @description: "CSS #9 (SV_ID=4)"
+
+  .AtoDGainFactor[10][1]:
+    @datatype: dReal
+    @default: 2.9921
+    @description: "CSS #10 (SV_ID=4)"
+
+  .AtoDGainFactor[10][2]:
+    @datatype: dReal
+    @default: 3.0279
+    @description: "CSS #10 (SV_ID=4)"
+
+  .AtoDGainFactor[11][1]:
+    @datatype: dReal
+    @default: 3.0550
+    @description: "CSS #11 (SV_ID=4)"
+
+  .AtoDGainFactor[11][2]:
+    @datatype: dReal
+    @default: 2.9650
+    @description: "CSS #11 (SV_ID=4)"
+
+  .AtoDGainFactor[12][1]:
+    @datatype: dReal
+    @default: 3.0540
+    @description: "CSS #12 (SV_ID=4)"
+
+  .AtoDGainFactor[12][2]:
+    @datatype: dReal
+    @default: 2.9660
+    @description: "CSS #12 (SV_ID=4)"
+
+  .AtoDGainFactor[13][1]:
+    @datatype: dReal
+    @default: 2.9952
+    @description: "CSS #13 (SV_ID=4)"
+
+  .AtoDGainFactor[13][2]:
+    @datatype: dReal
+    @default: 3.0248
+    @description: "CSS #13 (SV_ID=4)"
+
+  .AtoDGainFactor[14][1]:
+    @datatype: dReal
+    @default: 2.9937
+    @description: "CSS #14 (SV_ID=4)"
+
+  .AtoDGainFactor[14][2]:
+    @datatype: dReal
+    @default: 3.0263
+    @description: "CSS #14 (SV_ID=4)"
+
+  .AtoDGainFactor[15][1]:
+    @datatype: dReal
+    @default: 3.0543
+    @description: "CSS #15 (SV_ID=4)"
+
+  .AtoDGainFactor[15][2]:
+    @datatype: dReal
+    @default: 2.9657
+    @description: "CSS #15 (SV_ID=4)"
+
+  .AtoDGainFactor[16][1]:
+    @datatype: dReal
+    @default: 3.0542
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AtoDGainFactor[16][2]:
+    @datatype: dReal
+    @default: 2.9658
+    @description: "CSS #16 (SV_ID=4)"
+
+  .ScaleFactor:
+    @datatype: dReal
+    @default: 40.08
+    @description: "ScaleFactor (SV_ID=4)"
+
+  .RateCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "RateCycleMask, Calculate CSS Derived Rate Vector Cycle Mask (1 Hz) (SV_ID=4)"
+
+  .RateFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "RateFrameMask, Calculate CSS Derived Rate Vector Frame Mask, Every Frame 1 - 15 (SV_ID=4)"
+
+  .Spare1[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=4)"
+
+  .Spare1[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=4)"
+
+  .SdotFiltera1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFiltera1 (SV_ID=4)"
+
+  .SdotFilterb1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFilterb1 (SV_ID=4)"
+
+  .CoplanarLimit:
+    @datatype: dReal
+    @default: 5.0*DEG_2_RAD
+    @description: "CoplanarLimit (SV_ID=4)"
+
+  .AlbedoThr[1]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.37 * 0.069) Looking +Z in Stowed Configuration (SV_ID=4)"
+
+  .AlbedoThr[2]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.30 * 0.069) Otherwise (SV_ID=4)"
+
+  .AlbedoThr[3]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[4]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[5]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[6]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[7]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[8]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[9]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[10]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[11]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[12]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[13]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[14]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[15]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=4)"
+
+  .AlbedoThr[16]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=4)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=4)"
+
+  .MinDetectorCurrent[1]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "MinDetectorCurrent, Amp (SV_ID=4)"
+
+  .MinDetectorCurrent[2]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[3]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[4]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[5]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[6]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[7]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[8]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[9]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[10]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[11]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[12]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[13]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[14]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[15]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .MinDetectorCurrent[16]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=4)"
+
+  .CssBoresightBdy0[1][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=4)"
+
+  .CssBoresightBdy0[1][2]:
+    @datatype: uVector
+    @default: { { 0.002, 0.052, 0.102 } }
+    @description: "CSS#1 .... Stowed (SV_ID=4)"
+
+  .CssBoresightBdy0[1][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=4)"
+
+  .CssBoresightBdy0[2][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=4)"
+
+  .CssBoresightBdy0[2][2]:
+    @datatype: uVector
+    @default: { { 0.005, 0.055, 0.105 } }
+    @description: "CSS#1 .... Deploying (SV_ID=4)"
+
+  .CssBoresightBdy0[2][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=4)"
+
+  .CssBoresightBdy0[3][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[3][2]:
+    @datatype: uVector
+    @default: { { 0.008, 0.058, 0.108 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[3][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[4][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[4][2]:
+    @datatype: uVector
+    @default: { { 0.011, 0.061, 0.111 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[4][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[5][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[5][2]:
+    @datatype: uVector
+    @default: { { 0.014, 0.064, 0.114 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[5][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[6][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[6][2]:
+    @datatype: uVector
+    @default: { { 0.017, 0.067, 0.117 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[6][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[7][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[7][2]:
+    @datatype: uVector
+    @default: { { 0.020, 0.070, 0.120 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[7][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[8][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[8][2]:
+    @datatype: uVector
+    @default: { { 0.023, 0.073, 0.123 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[8][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[9][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[9][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[9][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[10][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[10][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[10][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[11][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[11][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[11][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[12][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[12][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[12][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[13][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[13][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[13][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[14][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[14][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[14][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[15][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[15][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[15][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[16][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[16][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .CssBoresightBdy0[16][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=4)"
+
+  .FailTimeOut:
+    @datatype: uWord
+    @default: 6 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "FailTimeOut, cycles (SV_ID=4)"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (SV_ID=4)"
+
+  .EndEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "EndEclipseCount (SV_ID=4)"
+
+  .MaxEclipseDuration[1]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "MaxEclipseDuration (72 min.) Stowed (SV_ID=4)"
+
+  .MaxEclipseDuration[2]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deploying (SV_ID=4)"
+
+  .MaxEclipseDuration[3]:
+    @datatype: uWord
+    @default: 72 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deployed (SV_ID=4)"
+
+  .Spare2[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=4)"
+
+  .Spare2[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=4)"
+
+  .EnableRiu2Tlm[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[9]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[10]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[11]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[12]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[13]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[14]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[15]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .EnableRiu2Tlm[16]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=4)"
+
+  .CssLocation[1]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[2]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[3]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[4]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[5]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[6]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[7]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[8]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[9]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[10]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[11]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[12]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[13]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[14]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[15]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .CssLocation[16]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=4)"
+
+  .AllowCSS[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[3][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[4][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[4][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[5][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[6][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[7][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[7][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[8][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[8][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[9][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[9][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[9][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[10][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[10][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[10][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[11][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[11][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[11][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[12][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[12][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[12][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[13][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[13][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[13][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[14][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[14][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[14][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[15][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[15][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[15][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[16][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[16][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .AllowCSS[16][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=4)"
+
+  .CurrentTestCnt[1]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[2]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[3]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[4]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[5]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[6]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[7]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[8]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[9]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[10]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[11]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[12]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[13]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[14]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[15]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .CurrentTestCnt[16]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=4)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=4)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=4)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=4)"
+
+  .AtoDGainFactor[1][1]:
+    @datatype: dReal
+    @default: 3.2905
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=5)"
+
+  .AtoDGainFactor[1][2]:
+    @datatype: dReal
+    @default: 2.7295
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=5)"
+
+  .AtoDGainFactor[2][1]:
+    @datatype: dReal
+    @default: 2.9737
+    @description: "CSS #2 (SV_ID=5)"
+
+  .AtoDGainFactor[2][2]:
+    @datatype: dReal
+    @default: 3.0463
+    @description: "CSS #2 (SV_ID=5)"
+
+  .AtoDGainFactor[3][1]:
+    @datatype: dReal
+    @default: 3.2913
+    @description: "CSS #3 (SV_ID=5)"
+
+  .AtoDGainFactor[3][2]:
+    @datatype: dReal
+    @default: 2.7287
+    @description: "CSS #3 (SV_ID=5)"
+
+  .AtoDGainFactor[4][1]:
+    @datatype: dReal
+    @default: 2.9716
+    @description: "CSS #4 (SV_ID=5)"
+
+  .AtoDGainFactor[4][2]:
+    @datatype: dReal
+    @default: 3.0484
+    @description: "CSS #4 (SV_ID=5)"
+
+  .AtoDGainFactor[5][1]:
+    @datatype: dReal
+    @default: 3.2920
+    @description: "CSS #5 (SV_ID=5)"
+
+  .AtoDGainFactor[5][2]:
+    @datatype: dReal
+    @default: 2.7280
+    @description: "CSS #5 (SV_ID=5)"
+
+  .AtoDGainFactor[6][1]:
+    @datatype: dReal
+    @default: 2.9687
+    @description: "CSS #6 (SV_ID=5)"
+
+  .AtoDGainFactor[6][2]:
+    @datatype: dReal
+    @default: 3.0513
+    @description: "CSS #6 (SV_ID=5)"
+
+  .AtoDGainFactor[7][1]:
+    @datatype: dReal
+    @default: 3.2948
+    @description: "CSS #7 (SV_ID=5)"
+
+  .AtoDGainFactor[7][2]:
+    @datatype: dReal
+    @default: 2.7252
+    @description: "CSS #7 (SV_ID=5)"
+
+  .AtoDGainFactor[8][1]:
+    @datatype: dReal
+    @default: 2.9693
+    @description: "CSS #8 (SV_ID=5)"
+
+  .AtoDGainFactor[8][2]:
+    @datatype: dReal
+    @default: 3.0507
+    @description: "CSS #8 (SV_ID=5)"
+
+  .AtoDGainFactor[9][1]:
+    @datatype: dReal
+    @default: 2.9662
+    @description: "CSS #9 (SV_ID=5)"
+
+  .AtoDGainFactor[9][2]:
+    @datatype: dReal
+    @default: 3.0538
+    @description: "CSS #9 (SV_ID=5)"
+
+  .AtoDGainFactor[10][1]:
+    @datatype: dReal
+    @default: 2.9656
+    @description: "CSS #10 (SV_ID=5)"
+
+  .AtoDGainFactor[10][2]:
+    @datatype: dReal
+    @default: 3.0544
+    @description: "CSS #10 (SV_ID=5)"
+
+  .AtoDGainFactor[11][1]:
+    @datatype: dReal
+    @default: 3.0393
+    @description: "CSS #11 (SV_ID=5)"
+
+  .AtoDGainFactor[11][2]:
+    @datatype: dReal
+    @default: 2.9807
+    @description: "CSS #11 (SV_ID=5)"
+
+  .AtoDGainFactor[12][1]:
+    @datatype: dReal
+    @default: 3.0402
+    @description: "CSS #12 (SV_ID=5)"
+
+  .AtoDGainFactor[12][2]:
+    @datatype: dReal
+    @default: 2.9798
+    @description: "CSS #12 (SV_ID=5)"
+
+  .AtoDGainFactor[13][1]:
+    @datatype: dReal
+    @default: 2.9631
+    @description: "CSS #13 (SV_ID=5)"
+
+  .AtoDGainFactor[13][2]:
+    @datatype: dReal
+    @default: 3.0569
+    @description: "CSS #13 (SV_ID=5)"
+
+  .AtoDGainFactor[14][1]:
+    @datatype: dReal
+    @default: 2.9650
+    @description: "CSS #14 (SV_ID=5)"
+
+  .AtoDGainFactor[14][2]:
+    @datatype: dReal
+    @default: 3.0550
+    @description: "CSS #14 (SV_ID=5)"
+
+  .AtoDGainFactor[15][1]:
+    @datatype: dReal
+    @default: 3.0413
+    @description: "CSS #15 (SV_ID=5)"
+
+  .AtoDGainFactor[15][2]:
+    @datatype: dReal
+    @default: 2.9787
+    @description: "CSS #15 (SV_ID=5)"
+
+  .AtoDGainFactor[16][1]:
+    @datatype: dReal
+    @default: 3.0422
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AtoDGainFactor[16][2]:
+    @datatype: dReal
+    @default: 2.9778
+    @description: "CSS #16 (SV_ID=5)"
+
+  .ScaleFactor:
+    @datatype: dReal
+    @default: 40.08
+    @description: "ScaleFactor (SV_ID=5)"
+
+  .RateCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "RateCycleMask, Calculate CSS Derived Rate Vector Cycle Mask (1 Hz) (SV_ID=5)"
+
+  .RateFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "RateFrameMask, Calculate CSS Derived Rate Vector Frame Mask, Every Frame 1 - 15 (SV_ID=5)"
+
+  .Spare1[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=5)"
+
+  .Spare1[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=5)"
+
+  .SdotFiltera1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFiltera1 (SV_ID=5)"
+
+  .SdotFilterb1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFilterb1 (SV_ID=5)"
+
+  .CoplanarLimit:
+    @datatype: dReal
+    @default: 5.0*DEG_2_RAD
+    @description: "CoplanarLimit (SV_ID=5)"
+
+  .AlbedoThr[1]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.37 * 0.069) Looking +Z in Stowed Configuration (SV_ID=5)"
+
+  .AlbedoThr[2]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.30 * 0.069) Otherwise (SV_ID=5)"
+
+  .AlbedoThr[3]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[4]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[5]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[6]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[7]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[8]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[9]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[10]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[11]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[12]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[13]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[14]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[15]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=5)"
+
+  .AlbedoThr[16]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=5)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=5)"
+
+  .MinDetectorCurrent[1]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "MinDetectorCurrent, Amp (SV_ID=5)"
+
+  .MinDetectorCurrent[2]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[3]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[4]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[5]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[6]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[7]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[8]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[9]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[10]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[11]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[12]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[13]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[14]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[15]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .MinDetectorCurrent[16]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=5)"
+
+  .CssBoresightBdy0[1][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=5)"
+
+  .CssBoresightBdy0[1][2]:
+    @datatype: uVector
+    @default: { { 0.002, 0.052, 0.102 } }
+    @description: "CSS#1 .... Stowed (SV_ID=5)"
+
+  .CssBoresightBdy0[1][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=5)"
+
+  .CssBoresightBdy0[2][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=5)"
+
+  .CssBoresightBdy0[2][2]:
+    @datatype: uVector
+    @default: { { 0.005, 0.055, 0.105 } }
+    @description: "CSS#1 .... Deploying (SV_ID=5)"
+
+  .CssBoresightBdy0[2][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=5)"
+
+  .CssBoresightBdy0[3][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[3][2]:
+    @datatype: uVector
+    @default: { { 0.008, 0.058, 0.108 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[3][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[4][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[4][2]:
+    @datatype: uVector
+    @default: { { 0.011, 0.061, 0.111 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[4][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[5][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[5][2]:
+    @datatype: uVector
+    @default: { { 0.014, 0.064, 0.114 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[5][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[6][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[6][2]:
+    @datatype: uVector
+    @default: { { 0.017, 0.067, 0.117 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[6][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[7][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[7][2]:
+    @datatype: uVector
+    @default: { { 0.020, 0.070, 0.120 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[7][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[8][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[8][2]:
+    @datatype: uVector
+    @default: { { 0.023, 0.073, 0.123 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[8][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[9][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[9][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[9][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[10][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[10][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[10][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[11][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[11][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[11][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[12][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[12][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[12][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[13][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[13][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[13][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[14][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[14][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[14][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[15][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[15][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[15][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[16][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[16][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .CssBoresightBdy0[16][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=5)"
+
+  .FailTimeOut:
+    @datatype: uWord
+    @default: 6 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "FailTimeOut, cycles (SV_ID=5)"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (SV_ID=5)"
+
+  .EndEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "EndEclipseCount (SV_ID=5)"
+
+  .MaxEclipseDuration[1]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "MaxEclipseDuration (72 min.) Stowed (SV_ID=5)"
+
+  .MaxEclipseDuration[2]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deploying (SV_ID=5)"
+
+  .MaxEclipseDuration[3]:
+    @datatype: uWord
+    @default: 72 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deployed (SV_ID=5)"
+
+  .Spare2[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=5)"
+
+  .Spare2[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=5)"
+
+  .EnableRiu2Tlm[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[9]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[10]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[11]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[12]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[13]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[14]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[15]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .EnableRiu2Tlm[16]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=5)"
+
+  .CssLocation[1]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[2]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[3]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[4]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[5]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[6]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[7]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[8]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[9]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[10]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[11]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[12]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[13]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[14]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[15]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .CssLocation[16]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=5)"
+
+  .AllowCSS[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[3][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[4][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[4][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[5][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[6][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[7][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[7][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[8][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[8][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[9][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[9][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[9][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[10][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[10][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[10][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[11][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[11][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[11][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[12][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[12][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[12][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[13][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[13][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[13][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[14][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[14][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[14][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[15][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[15][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[15][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[16][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[16][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .AllowCSS[16][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=5)"
+
+  .CurrentTestCnt[1]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[2]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[3]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[4]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[5]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[6]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[7]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[8]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[9]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[10]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[11]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[12]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[13]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[14]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[15]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .CurrentTestCnt[16]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=5)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=5)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=5)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=5)"
+
+  .AtoDGainFactor[1][1]:
+    @datatype: dReal
+    @default: 3.2162
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=6)"
+
+  .AtoDGainFactor[1][2]:
+    @datatype: dReal
+    @default: 2.8038
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=6)"
+
+  .AtoDGainFactor[2][1]:
+    @datatype: dReal
+    @default: 2.9809
+    @description: "CSS #2 (SV_ID=6)"
+
+  .AtoDGainFactor[2][2]:
+    @datatype: dReal
+    @default: 3.0391
+    @description: "CSS #2 (SV_ID=6)"
+
+  .AtoDGainFactor[3][1]:
+    @datatype: dReal
+    @default: 3.2151
+    @description: "CSS #3 (SV_ID=6)"
+
+  .AtoDGainFactor[3][2]:
+    @datatype: dReal
+    @default: 2.8049
+    @description: "CSS #3 (SV_ID=6)"
+
+  .AtoDGainFactor[4][1]:
+    @datatype: dReal
+    @default: 2.9814
+    @description: "CSS #4 (SV_ID=6)"
+
+  .AtoDGainFactor[4][2]:
+    @datatype: dReal
+    @default: 3.0386
+    @description: "CSS #4 (SV_ID=6)"
+
+  .AtoDGainFactor[5][1]:
+    @datatype: dReal
+    @default: 3.2172
+    @description: "CSS #5 (SV_ID=6)"
+
+  .AtoDGainFactor[5][2]:
+    @datatype: dReal
+    @default: 2.8028
+    @description: "CSS #5 (SV_ID=6)"
+
+  .AtoDGainFactor[6][1]:
+    @datatype: dReal
+    @default: 2.9810
+    @description: "CSS #6 (SV_ID=6)"
+
+  .AtoDGainFactor[6][2]:
+    @datatype: dReal
+    @default: 3.0390
+    @description: "CSS #6 (SV_ID=6)"
+
+  .AtoDGainFactor[7][1]:
+    @datatype: dReal
+    @default: 3.2213
+    @description: "CSS #7 (SV_ID=6)"
+
+  .AtoDGainFactor[7][2]:
+    @datatype: dReal
+    @default: 2.7987
+    @description: "CSS #7 (SV_ID=6)"
+
+  .AtoDGainFactor[8][1]:
+    @datatype: dReal
+    @default: 2.9801
+    @description: "CSS #8 (SV_ID=6)"
+
+  .AtoDGainFactor[8][2]:
+    @datatype: dReal
+    @default: 3.0399
+    @description: "CSS #8 (SV_ID=6)"
+
+  .AtoDGainFactor[9][1]:
+    @datatype: dReal
+    @default: 2.9592
+    @description: "CSS #9 (SV_ID=6)"
+
+  .AtoDGainFactor[9][2]:
+    @datatype: dReal
+    @default: 3.0608
+    @description: "CSS #9 (SV_ID=6)"
+
+  .AtoDGainFactor[10][1]:
+    @datatype: dReal
+    @default: 2.9569
+    @description: "CSS #10 (SV_ID=6)"
+
+  .AtoDGainFactor[10][2]:
+    @datatype: dReal
+    @default: 3.0631
+    @description: "CSS #10 (SV_ID=6)"
+
+  .AtoDGainFactor[11][1]:
+    @datatype: dReal
+    @default: 3.0192
+    @description: "CSS #11 (SV_ID=6)"
+
+  .AtoDGainFactor[11][2]:
+    @datatype: dReal
+    @default: 3.0008
+    @description: "CSS #11 (SV_ID=6)"
+
+  .AtoDGainFactor[12][1]:
+    @datatype: dReal
+    @default: 3.0190
+    @description: "CSS #12 (SV_ID=6)"
+
+  .AtoDGainFactor[12][2]:
+    @datatype: dReal
+    @default: 3.0010
+    @description: "CSS #12 (SV_ID=6)"
+
+  .AtoDGainFactor[13][1]:
+    @datatype: dReal
+    @default: 2.9609
+    @description: "CSS #13 (SV_ID=6)"
+
+  .AtoDGainFactor[13][2]:
+    @datatype: dReal
+    @default: 3.0591
+    @description: "CSS #13 (SV_ID=6)"
+
+  .AtoDGainFactor[14][1]:
+    @datatype: dReal
+    @default: 2.9580
+    @description: "CSS #14 (SV_ID=6)"
+
+  .AtoDGainFactor[14][2]:
+    @datatype: dReal
+    @default: 3.0620
+    @description: "CSS #14 (SV_ID=6)"
+
+  .AtoDGainFactor[15][1]:
+    @datatype: dReal
+    @default: 3.0192
+    @description: "CSS #15 (SV_ID=6)"
+
+  .AtoDGainFactor[15][2]:
+    @datatype: dReal
+    @default: 3.0008
+    @description: "CSS #15 (SV_ID=6)"
+
+  .AtoDGainFactor[16][1]:
+    @datatype: dReal
+    @default: 3.0193
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AtoDGainFactor[16][2]:
+    @datatype: dReal
+    @default: 3.0007
+    @description: "CSS #16 (SV_ID=6)"
+
+  .ScaleFactor:
+    @datatype: dReal
+    @default: 40.08
+    @description: "ScaleFactor (SV_ID=6)"
+
+  .RateCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "RateCycleMask, Calculate CSS Derived Rate Vector Cycle Mask (1 Hz) (SV_ID=6)"
+
+  .RateFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "RateFrameMask, Calculate CSS Derived Rate Vector Frame Mask, Every Frame 1 - 15 (SV_ID=6)"
+
+  .Spare1[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=6)"
+
+  .Spare1[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=6)"
+
+  .SdotFiltera1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFiltera1 (SV_ID=6)"
+
+  .SdotFilterb1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFilterb1 (SV_ID=6)"
+
+  .CoplanarLimit:
+    @datatype: dReal
+    @default: 5.0*DEG_2_RAD
+    @description: "CoplanarLimit (SV_ID=6)"
+
+  .AlbedoThr[1]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.37 * 0.069) Looking +Z in Stowed Configuration (SV_ID=6)"
+
+  .AlbedoThr[2]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.30 * 0.069) Otherwise (SV_ID=6)"
+
+  .AlbedoThr[3]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[4]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[5]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[6]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[7]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[8]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[9]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[10]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[11]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[12]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[13]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[14]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[15]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=6)"
+
+  .AlbedoThr[16]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=6)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=6)"
+
+  .MinDetectorCurrent[1]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "MinDetectorCurrent, Amp (SV_ID=6)"
+
+  .MinDetectorCurrent[2]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[3]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[4]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[5]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[6]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[7]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[8]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[9]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[10]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[11]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[12]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[13]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[14]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[15]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .MinDetectorCurrent[16]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=6)"
+
+  .CssBoresightBdy0[1][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=6)"
+
+  .CssBoresightBdy0[1][2]:
+    @datatype: uVector
+    @default: { { 0.002, 0.052, 0.102 } }
+    @description: "CSS#1 .... Stowed (SV_ID=6)"
+
+  .CssBoresightBdy0[1][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=6)"
+
+  .CssBoresightBdy0[2][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=6)"
+
+  .CssBoresightBdy0[2][2]:
+    @datatype: uVector
+    @default: { { 0.005, 0.055, 0.105 } }
+    @description: "CSS#1 .... Deploying (SV_ID=6)"
+
+  .CssBoresightBdy0[2][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=6)"
+
+  .CssBoresightBdy0[3][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[3][2]:
+    @datatype: uVector
+    @default: { { 0.008, 0.058, 0.108 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[3][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[4][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[4][2]:
+    @datatype: uVector
+    @default: { { 0.011, 0.061, 0.111 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[4][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[5][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[5][2]:
+    @datatype: uVector
+    @default: { { 0.014, 0.064, 0.114 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[5][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[6][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[6][2]:
+    @datatype: uVector
+    @default: { { 0.017, 0.067, 0.117 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[6][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[7][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[7][2]:
+    @datatype: uVector
+    @default: { { 0.020, 0.070, 0.120 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[7][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[8][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[8][2]:
+    @datatype: uVector
+    @default: { { 0.023, 0.073, 0.123 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[8][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[9][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[9][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[9][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[10][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[10][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[10][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[11][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[11][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[11][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[12][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[12][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[12][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[13][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[13][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[13][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[14][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[14][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[14][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[15][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[15][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[15][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[16][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[16][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .CssBoresightBdy0[16][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=6)"
+
+  .FailTimeOut:
+    @datatype: uWord
+    @default: 6 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "FailTimeOut, cycles (SV_ID=6)"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (SV_ID=6)"
+
+  .EndEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "EndEclipseCount (SV_ID=6)"
+
+  .MaxEclipseDuration[1]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "MaxEclipseDuration (72 min.) Stowed (SV_ID=6)"
+
+  .MaxEclipseDuration[2]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deploying (SV_ID=6)"
+
+  .MaxEclipseDuration[3]:
+    @datatype: uWord
+    @default: 72 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deployed (SV_ID=6)"
+
+  .Spare2[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=6)"
+
+  .Spare2[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=6)"
+
+  .EnableRiu2Tlm[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[9]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[10]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[11]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[12]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[13]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[14]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[15]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .EnableRiu2Tlm[16]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=6)"
+
+  .CssLocation[1]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[2]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[3]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[4]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[5]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[6]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[7]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[8]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[9]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[10]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[11]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[12]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[13]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[14]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[15]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .CssLocation[16]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=6)"
+
+  .AllowCSS[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[3][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[4][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[4][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[5][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[6][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[7][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[7][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[8][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[8][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[9][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[9][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[9][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[10][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[10][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[10][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[11][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[11][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[11][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[12][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[12][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[12][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[13][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[13][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[13][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[14][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[14][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[14][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[15][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[15][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[15][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[16][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[16][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .AllowCSS[16][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=6)"
+
+  .CurrentTestCnt[1]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[2]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[3]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[4]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[5]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[6]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[7]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[8]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[9]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[10]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[11]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[12]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[13]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[14]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[15]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .CurrentTestCnt[16]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=6)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "Ideal Max Current for GaAs Solar Cells MaxDetectorCurrent, Amp (SV_ID=6)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=6)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=6)"
+
+  .AtoDGainFactor[1][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[1][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "AtoDGainFactor (doubled for GaAs CSSs per DN-HORNET-CDH-052) RIU1 RIU2 CSS #1 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[2][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #2 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[2][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #2 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[3][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #3 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[3][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #3 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[4][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #4 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[4][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #4 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[5][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #5 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[5][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #5 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[6][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #6 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[6][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #6 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[7][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #7 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[7][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #7 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[8][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #8 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[8][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #8 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[9][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #9 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[9][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #9 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[10][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #10 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[10][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #10 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[11][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #11 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[11][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #11 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[12][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #12 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[12][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #12 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[13][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #13 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[13][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #13 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[14][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #14 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[14][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #14 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[15][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #15 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[15][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #15 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[16][1]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AtoDGainFactor[16][2]:
+    @datatype: dReal
+    @default: 3.01
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .ScaleFactor:
+    @datatype: dReal
+    @default: 40.08
+    @description: "ScaleFactor (SV_ID=ELSE)"
+
+  .RateCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "RateCycleMask, Calculate CSS Derived Rate Vector Cycle Mask (1 Hz) (SV_ID=ELSE)"
+
+  .RateFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "RateFrameMask, Calculate CSS Derived Rate Vector Frame Mask, Every Frame 1 - 15 (SV_ID=ELSE)"
+
+  .Spare1[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=ELSE)"
+
+  .Spare1[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding (SV_ID=ELSE)"
+
+  .SdotFiltera1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFiltera1 (SV_ID=ELSE)"
+
+  .SdotFilterb1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "SdotFilterb1 (SV_ID=ELSE)"
+
+  .CoplanarLimit:
+    @datatype: dReal
+    @default: 5.0*DEG_2_RAD
+    @description: "CoplanarLimit (SV_ID=ELSE)"
+
+  .AlbedoThr[1]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.37 * 0.069) Looking +Z in Stowed Configuration (SV_ID=ELSE)"
+
+  .AlbedoThr[2]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "AlbedoThr, Amp (0.30 * 0.069) Otherwise (SV_ID=ELSE)"
+
+  .AlbedoThr[3]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[4]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[5]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[6]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[7]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[8]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[9]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[10]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[11]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[12]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[13]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[14]:
+    @datatype: dReal
+    @default: 0.0255
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[15]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=ELSE)"
+
+  .AlbedoThr[16]:
+    @datatype: dReal
+    @default: 0.0207
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "MaxDetectorCurrent, Amp (SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.069
+    @description: "(SV_ID=ELSE)"
+
+  .MinDetectorCurrent[1]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "MinDetectorCurrent, Amp (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[2]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[3]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[4]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[5]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[6]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[7]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[8]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[9]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[10]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[11]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[12]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[13]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[14]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[15]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .MinDetectorCurrent[16]:
+    @datatype: dReal
+    @default: -0.002
+    @description: "CssBoresightBdy0 (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[1][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[1][2]:
+    @datatype: uVector
+    @default: { { 0.002, 0.052, 0.102 } }
+    @description: "CSS#1 .... Stowed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[1][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Stowed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[2][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[2][2]:
+    @datatype: uVector
+    @default: { { 0.005, 0.055, 0.105 } }
+    @description: "CSS#1 .... Deploying (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[2][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#1 .... Deploying (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[3][1]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[3][2]:
+    @datatype: uVector
+    @default: { { 0.008, 0.058, 0.108 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[3][3]:
+    @datatype: uVector
+    @default: { { 0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[4][1]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[4][2]:
+    @datatype: uVector
+    @default: { { 0.011, 0.061, 0.111 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[4][3]:
+    @datatype: uVector
+    @default: { { 0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[5][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[5][2]:
+    @datatype: uVector
+    @default: { { 0.014, 0.064, 0.114 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[5][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[6][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[6][2]:
+    @datatype: uVector
+    @default: { { 0.017, 0.067, 0.117 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[6][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[7][1]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[7][2]:
+    @datatype: uVector
+    @default: { { 0.020, 0.070, 0.120 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[7][3]:
+    @datatype: uVector
+    @default: { { -0.57735, 0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[8][1]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, 0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[8][2]:
+    @datatype: uVector
+    @default: { { 0.023, 0.073, 0.123 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[8][3]:
+    @datatype: uVector
+    @default: { { -0.57735, -0.57735, -0.57735 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[9][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[9][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[9][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[10][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[10][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[10][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[11][1]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[11][2]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[11][3]:
+    @datatype: uVector
+    @default: { { 0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[12][1]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[12][2]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[12][3]:
+    @datatype: uVector
+    @default: { { 0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[13][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[13][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[13][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[14][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[14][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[14][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, 0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[15][1]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[15][2]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[15][3]:
+    @datatype: uVector
+    @default: { { -0.40558, 0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[16][1]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[16][2]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .CssBoresightBdy0[16][3]:
+    @datatype: uVector
+    @default: { { -0.40558, -0.40558, -0.81915 } }
+    @description: "CSS#16 ... Deployed (SV_ID=ELSE)"
+
+  .FailTimeOut:
+    @datatype: uWord
+    @default: 6 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "FailTimeOut, cycles (SV_ID=ELSE)"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (SV_ID=ELSE)"
+
+  .EndEclipseCount:
+    @datatype: uWord
+    @default: 2 * NUM_AC_CYCLES
+    @description: "EndEclipseCount (SV_ID=ELSE)"
+
+  .MaxEclipseDuration[1]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "MaxEclipseDuration (72 min.) Stowed (SV_ID=ELSE)"
+
+  .MaxEclipseDuration[2]:
+    @datatype: uWord
+    @default: 0 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deploying (SV_ID=ELSE)"
+
+  .MaxEclipseDuration[3]:
+    @datatype: uWord
+    @default: 72 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "Deployed (SV_ID=ELSE)"
+
+  .Spare2[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=ELSE)"
+
+  .Spare2[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare EnableRiu2Tlm (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[9]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[10]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[11]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[12]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[13]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[14]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[15]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .EnableRiu2Tlm[16]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CssLocation (SV_ID=ELSE)"
+
+  .CssLocation[1]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[2]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[3]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[4]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[5]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[6]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[7]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD2
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[8]:
+    @datatype: uWord
+    @default: CSS_LOC_SAD1
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[9]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[10]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[11]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[12]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[13]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[14]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[15]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .CssLocation[16]:
+    @datatype: uWord
+    @default: CSS_LOC_BDY
+    @description: "Stowed Deploying Deployed --- AllowCSS, NA ... (SV_ID=ELSE)"
+
+  .AllowCSS[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[1][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[2][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[3][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[3][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[4][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[4][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[4][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[5][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[5][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[5][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[6][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[6][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[6][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[7][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[7][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[7][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[8][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[8][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[8][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[9][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[9][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[9][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[10][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[10][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[10][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[11][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[11][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[11][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[12][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[12][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[12][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[13][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[13][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[13][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[14][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[14][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[14][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[15][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[15][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[15][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[16][1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[16][2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .AllowCSS[16][3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "CSS #16 (SV_ID=ELSE)"
+
+  .CurrentTestCnt[1]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[2]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[3]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[4]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[5]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[6]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[7]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[8]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[9]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[10]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[11]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[12]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[13]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[14]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[15]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .CurrentTestCnt[16]:
+    @datatype: uWord
+    @default: 5*NUM_AC_CYCLES
+    @description: "Fdc.CurrentTestCnt, cnt (SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[1]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "MaxDetectorCurrent, Amp (SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[2]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[3]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[4]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[5]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[6]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[7]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[8]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[9]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[10]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[11]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[12]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[13]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[14]:
+    @datatype: dReal
+    @default: 0.0998
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[15]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=ELSE)"
+
+  .MaxDetectorCurrent[16]:
+    @datatype: dReal
+    @default: 0.0941
+    @description: "(SV_ID=ELSE)"
+
+}
+
+table ac_gps_table_type {
+  @buildstruct!
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "CycleMask, GPS Command Cycle Mask (10 Hz)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, GPS Frame Mask, Every Frame 1 - 15"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3 * NUM_AN_CYCLES
+    @description: "PowerOffCnt , AN Cycles"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 10 * NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt , AC Cycles"
+
+  .RangeLoadTestCnt:
+    @datatype: uWord
+    @default: 4 * HR_2_SEC*NUM_AN_CYCLES
+    @description: "RangeLoadTestCnt , AN Cycles"
+
+  .PosChanLoadTestCnt:
+    @datatype: uWord
+    @default: 1 * HR_2_SEC*NUM_AN_CYCLES
+    @description: "PosChanLoadTestCnt, AN Cycles"
+
+  .GoodsModeTestCnt:
+    @datatype: uWord
+    @default: 0 * NUM_AN_CYCLES
+    @description: "GoodsModeTestCnt , AN Cycles"
+
+  .WarmupTimer:
+    @datatype: uWord
+    @default: 60 * NUM_AN_CYCLES
+    @description: "WarmupTimer , AN Cycles"
+
+  .RangeUpdateTimer:
+    @datatype: uWord
+    @default: 30 * NUM_AN_CYCLES
+    @description: "RangeUpdateTimer , AN Cycles"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+}
+
+table ac_iru_table_type {
+  @buildstruct!
+  .DcmBdytoIru:
+    @datatype: uMatrix
+    @default: {{{ 0.0, 0.0, 1.0}, { -1.0, 0.0, 0.0}, { 0.0, -1.0, 0.0}}}
+    @description: "The Following Values Are Design Values (Perfect Alignment) based on DN-SERAPHIM-GNC-001 rev A Sect. 4.2.1.2"
+
+  .DcmIruToGyr[1]:
+    @datatype: uVector
+    @default: { { 0.577350269189626, 0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToGyr[GYRD], ND Accelerometer DCMs: Design Values (Perfect Alignment) based on DN-SERAPHIM-GNC-326 Sect. 4.5.3"
+
+  .DcmIruToGyr[2]:
+    @datatype: uVector
+    @default: { { 0.577350269189626, -0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToGyr[GYRD], ND Accelerometer DCMs: Design Values (Perfect Alignment) based on DN-SERAPHIM-GNC-326 Sect. 4.5.3"
+
+  .DcmIruToGyr[3]:
+    @datatype: uVector
+    @default: { { -0.577350269189626, -0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToGyr[GYRD], ND Accelerometer DCMs: Design Values (Perfect Alignment) based on DN-SERAPHIM-GNC-326 Sect. 4.5.3"
+
+  .DcmIruToGyr[4]:
+    @datatype: uVector
+    @default: { { -0.577350269189626, 0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToGyr[GYRD], ND Accelerometer DCMs: Design Values (Perfect Alignment) based on DN-SERAPHIM-GNC-326 Sect. 4.5.3"
+
+  .DcmIruToAcc[1]:
+    @datatype: uVector
+    @default: { { -0.577350269189626, 0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToAcc[ACCD], ND SSIRU Frame location in the SC frame Reference: SER-GNC-MEMO-005 SSIRU Location Table 2"
+
+  .DcmIruToAcc[2]:
+    @datatype: uVector
+    @default: { { -0.577350269189626, -0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToAcc[ACCD], ND SSIRU Frame location in the SC frame Reference: SER-GNC-MEMO-005 SSIRU Location Table 2"
+
+  .DcmIruToAcc[3]:
+    @datatype: uVector
+    @default: { { 0.577350269189626, -0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToAcc[ACCD], ND SSIRU Frame location in the SC frame Reference: SER-GNC-MEMO-005 SSIRU Location Table 2"
+
+  .DcmIruToAcc[4]:
+    @datatype: uVector
+    @default: { { 0.577350269189626, 0.577350269189626, 0.577350269189626 } }
+    @description: "DcmIruToAcc[ACCD], ND SSIRU Frame location in the SC frame Reference: SER-GNC-MEMO-005 SSIRU Location Table 2"
+
+  .IruPositionScFrame:
+    @datatype: uVector
+    @default: { 0.3938, 0.4864, 1.0333 }
+    @description: "IruPositionScFrame, m Accelerometer ECM positions in the SSIRU coordinate frame relative to the origin Accelerometer positions based on Seraphim SSIRU Accelerometer Locations Rev A Reference: SER-GNC-MEMO-005 SSIRU Location Table 1"
+
+  .AccPositionIru[1]:
+    @datatype: uVector
+    @default: { { 0.02122, 0.09204, 0.02908 } }
+    @description: "AccPositionIru[ACCC][3], m"
+
+  .AccPositionIru[2]:
+    @datatype: uVector
+    @default: { { 0.02122, -0.09204, 0.02908 } }
+    @description: "AccPositionIru[ACCC][3], m"
+
+  .AccPositionIru[3]:
+    @datatype: uVector
+    @default: { { -0.02122, -0.09204, 0.02908 } }
+    @description: "AccPositionIru[ACCC][3], m"
+
+  .AccPositionIru[4]:
+    @datatype: uVector
+    @default: { { -0.02122, 0.09204, 0.02908 } }
+    @description: "AccPositionIru[ACCC][3], m"
+
+  .ThetaLatency[1]:
+    @datatype: dReal
+    @default: 35.0e-3 + MF_CYCLE_TIME
+    @description: "ThetaLatency (sec)"
+
+  .ThetaLatency[2]:
+    @datatype: dReal
+    @default: 35.0e-3 + MF_CYCLE_TIME
+
+  .OmegaLatency[1]:
+    @datatype: dReal
+    @default: 35.0e-3 + MF_CYCLE_TIME + 0.5 * IRU_CYCLE_TIME
+    @description: "OmegaLatency (sec)"
+
+  .OmegaLatency[2]:
+    @datatype: dReal
+    @default: 35.0e-3 + MF_CYCLE_TIME + 0.5 * IRU_CYCLE_TIME
+
+  .GyrAngleWhiteNoise:
+    @datatype: dReal
+    @default: SQR(0.00794 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] GyrAngleWhiteNoise [0.003 arc-sec/rt(Hz)*rt(7Hz)(B.W.)]"
+
+  .GyrAngleRandomWalk:
+    @datatype: dReal
+    @default: SQR(0.009 * ARCSEC_2_RAD)
+    @description: "[rad^2/sec ] GyrAngleRandomWalk"
+
+  .GyrRateRandomWalk:
+    @datatype: dReal
+    @default: SQR(0 * ARCSEC_2_RAD)
+    @description: "[rad^2/sec^3 ] GyrRateRandomWalk"
+
+  .ScaleFactor[1][1]:
+    @datatype: dReal
+    @default: 0.05*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRA ] ScaleFactor[0][0]"
+
+  .ScaleFactor[2][1]:
+    @datatype: dReal
+    @default: 0.05*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRB ] ScaleFactor[0][1]"
+
+  .ScaleFactor[3][1]:
+    @datatype: dReal
+    @default: 0.05*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRC ] ScaleFactor[0][2]"
+
+  .ScaleFactor[4][1]:
+    @datatype: dReal
+    @default: 0.05*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRD ] ScaleFactor[0][3]"
+
+  .ScaleFactor[5][1]:
+    @datatype: dReal
+    @default: 1.60*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRA ] ScaleFactor[1][0]"
+
+  .ScaleFactor[6][1]:
+    @datatype: dReal
+    @default: 1.60*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRB ] ScaleFactor[1][1]"
+
+  .ScaleFactor[7][1]:
+    @datatype: dReal
+    @default: 1.60*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRC ] ScaleFactor[1][2]"
+
+  .ScaleFactor[8][1]:
+    @datatype: dReal
+    @default: 1.60*ARCSEC_2_RAD
+    @description: "[rad/LSB, GYRD ] ScaleFactor[1][3]"
+
+  .AccelScaleFactor[1]:
+    @datatype: dReal
+    @default: 1.2207E-9
+    @description: "[(m/s)/LSB, ACCA ] AccelScaleFactor[0], SSIRU EICD - 6B04982 Rev A Section 4.6.2.8"
+
+  .AccelScaleFactor[2]:
+    @datatype: dReal
+    @default: 1.2207E-9
+    @description: "[(m/s)/LSB, ACCB ] AccelScaleFactor[1], SSIRU EICD - 6B04982 Rev A Section 4.6.2.8"
+
+  .AccelScaleFactor[3]:
+    @datatype: dReal
+    @default: 1.2207E-9
+    @description: "[(m/s)/LSB, ACCB ] AccelScaleFactor[2], SSIRU EICD - 6B04982 Rev A Section 4.6.2.8"
+
+  .AccelScaleFactor[4]:
+    @datatype: dReal
+    @default: 1.2207E-9
+    @description: "[(m/s)/LSB, ACCB ] AccelScaleFactor[3], SSIRU EICD - 6B04982 Rev A Section 4.6.2.8"
+
+  .DefaultGyrBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "[rad/sec, GYRA ] DefaultGyrBias[0]"
+
+  .DefaultGyrBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "[rad/sec, GYRB ] DefaultGyrBias[1]"
+
+  .DefaultGyrBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "[rad/sec, GYRC ] DefaultGyrBias[2]"
+
+  .DefaultGyrBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "[rad/sec, GYRD ] DefaultGyrBias[3]"
+
+  .DefaultAccBias[1]:
+    @datatype: dReal
+    @default: 0.018
+    @description: "[m/sec^2, ACCA ] DefaultAccBias[0]"
+
+  .DefaultAccBias[2]:
+    @datatype: dReal
+    @default: 0.018
+    @description: "[m/sec^2, ACCB ] DefaultAccBias[1]"
+
+  .DefaultAccBias[3]:
+    @datatype: dReal
+    @default: 0.018
+    @description: "[m/sec^2, ACCC ] DefaultAccBias[2]"
+
+  .DefaultAccBias[4]:
+    @datatype: dReal
+    @default: 0.018
+    @description: "[m/sec^2, ACCD ] DefaultAccBias[3]"
+
+  .IruBiasLmt:
+    @datatype: uVector
+    @default: { { 4.0*ARCSEC_2_RAD , 4.0*ARCSEC_2_RAD , 4.0*ARCSEC_2_RAD } }
+
+  .TimeScaleFactor:
+    @datatype: dReal
+    @default: 4.0E-6
+    @description: "[sec/cnt ] TimeScaleFactor"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: 400.0
+    @description: "[sec ] WarmUpTime"
+
+  .TimeCntMax:
+    @datatype: dword
+    @default: 65535
+    @description: "[cnt ] TimeCntMax"
+
+  .EnableGyroLatencyCompDefault:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] EnableGyroLatencyCompDefault"
+
+  .EnaGyroLatencyCompDuringBusSlew:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] EnaGyroLatencyCompDuringBusSlew"
+
+  .EnaGyroLatencyCompInPldState[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "EnaGyroLatencyCompInPldState [True/False ] PD_FAULT"
+
+  .EnaGyroLatencyCompInPldState[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_IDLE"
+
+  .EnaGyroLatencyCompInPldState[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_HOLD"
+
+  .EnaGyroLatencyCompInPldState[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_SLEWING"
+
+  .EnaGyroLatencyCompInPldState[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_TRACKING"
+
+  .EnaGyroLatencyCompInPldState[6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_DECELERATE"
+
+  .EnaGyroLatencyCompInPldState[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_TRACK_TABLE"
+
+  .EnaGyroLatencyCompInPldState[8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_COMM_ANGLE"
+
+  .QuiescentPayloadState[1]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "QuiescentPayloadState [True/False ] PD_FAULT"
+
+  .QuiescentPayloadState[2]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_IDLE"
+
+  .QuiescentPayloadState[3]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_HOLD"
+
+  .QuiescentPayloadState[4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_SLEWING"
+
+  .QuiescentPayloadState[5]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_TRACKING"
+
+  .QuiescentPayloadState[6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_DECELERATE"
+
+  .QuiescentPayloadState[7]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_TRACK_TABLE"
+
+  .QuiescentPayloadState[8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_COMM_ANGLE"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_AC_CYCLES
+    @description: "[cnt ] PowerOffCnt"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare[0]"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare[1]"
+
+  .Spare[3]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare[2]"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 15*NUM_AC_CYCLES
+    @description: "[cnt ] Fdc.PowerStatusOffCnt"
+
+  .ConstantTimeCnt:
+    @datatype: uWord
+    @default: 15*NUM_IRU_CYCLES
+    @description: "[cnt ] Fdc.ConstantTimeCnt"
+
+  .ResonatorTempCnt:
+    @datatype: uWord
+    @default: 60*NUM_IRU_CYCLES
+    @description: "[cnt ] Fdc.ResonatorTempCnt"
+
+  .GyroStatusErrCnt[1]:
+    @datatype: uWord
+    @default: 15*NUM_IRU_CYCLES
+    @description: "[cnt, GYRA ] Fdc.GyroStatusErrCnt[0]"
+
+  .GyroStatusErrCnt[2]:
+    @datatype: uWord
+    @default: 15*NUM_IRU_CYCLES
+    @description: "[cnt, GYRB ] Fdc.GyroStatusErrCnt[1]"
+
+  .GyroStatusErrCnt[3]:
+    @datatype: uWord
+    @default: 15*NUM_IRU_CYCLES
+    @description: "[cnt, GYRC ] Fdc.GyroStatusErrCnt[2]"
+
+  .GyroStatusErrCnt[4]:
+    @datatype: uWord
+    @default: 15*NUM_IRU_CYCLES
+    @description: "[cnt, GYRD ] Fdc.GyroStatusErrCnt[3]"
+
+  .AccelStatusErrCnt[1]:
+    @datatype: uWord
+    @default: 15*NUM_AC_CYCLES
+    @description: "[cnt, ACCA ] Fdc.AccelStatusErrCnt[0]"
+
+  .AccelStatusErrCnt[2]:
+    @datatype: uWord
+    @default: 15*NUM_AC_CYCLES
+    @description: "[cnt, ACCB ] Fdc.AccelStatusErrCnt[1]"
+
+  .AccelStatusErrCnt[3]:
+    @datatype: uWord
+    @default: 15*NUM_AC_CYCLES
+    @description: "[cnt, ACCC ] Fdc.AccelStatusErrCnt[2]"
+
+  .AccelStatusErrCnt[4]:
+    @datatype: uWord
+    @default: 15*NUM_AC_CYCLES
+    @description: "[cnt, ACCD ] Fdc.AccelStatusErrCnt[3]"
+
+  .ConstantAngleDataCnt[1]:
+    @datatype: uWord
+    @default: 30*NUM_IRU_CYCLES
+    @description: "[cnt, GYRA ] Fdc.ConstantAngleDataCnt[0]"
+
+  .ConstantAngleDataCnt[2]:
+    @datatype: uWord
+    @default: 30*NUM_IRU_CYCLES
+    @description: "[cnt, GYRB ] Fdc.ConstantAngleDataCnt[1]"
+
+  .ConstantAngleDataCnt[3]:
+    @datatype: uWord
+    @default: 30*NUM_IRU_CYCLES
+    @description: "[cnt, GYRC ] Fdc.ConstantAngleDataCnt[2]"
+
+  .ConstantAngleDataCnt[4]:
+    @datatype: uWord
+    @default: 30*NUM_IRU_CYCLES
+    @description: "[cnt, GYRD ] Fdc.ConstantAngleDataCnt[3]"
+
+  .ConstantVelDataCnt[1]:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "[cnt, ACCA ] Fdc.ConstantVelDataCnt[0]"
+
+  .ConstantVelDataCnt[2]:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "[cnt, ACCB ] Fdc.ConstantVelDataCnt[1]"
+
+  .ConstantVelDataCnt[3]:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "[cnt, ACCC ] Fdc.ConstantVelDataCnt[2]"
+
+  .ConstantVelDataCnt[4]:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "[cnt, ACCD ] Fdc.ConstantVelDataCnt[3]"
+
+  .AngleGlitchCnt[1]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, GYRA ] Fdc.AngleGlitchCnt[0]"
+
+  .AngleGlitchCnt[2]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, GYRB ] Fdc.AngleGlitchCnt[1]"
+
+  .AngleGlitchCnt[3]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, GYRC ] Fdc.AngleGlitchCnt[2]"
+
+  .AngleGlitchCnt[4]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, GYRD ] Fdc.AngleGlitchCnt[3]"
+
+  .AccelGlitchCnt[1]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, ACCA ] Fdc.AccelGlitchCnt[0]"
+
+  .AccelGlitchCnt[2]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, ACCB ] Fdc.AccelGlitchCnt[1]"
+
+  .AccelGlitchCnt[3]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, ACCC ] Fdc.AccelGlitchCnt[2]"
+
+  .AccelGlitchCnt[4]:
+    @datatype: uWord
+    @default: 4
+    @description: "[cnt, ACCD ] Fdc.AccelGlitchCnt[3]"
+
+  .IruCorrectCnt:
+    @datatype: uWord
+    @default: 460*NUM_AC_CYCLES
+    @description: "[cnt ] Fdc.IruCorrectCnt"
+
+  .IruVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "[cnt ] Fdc.IruVerifyCnt"
+
+  .IruSafeSwitchWaitCnt:
+    @datatype: uWord
+    @default: 600 * NUM_AC_CYCLES
+    @description: "[cnt ] Fdc.IruSafeSwitchWaitCnt"
+
+  .IruSafeSwitchVerifyCnt:
+    @datatype: uWord
+    @default: 900 * NUM_AC_CYCLES
+    @description: "[cnt, >IruCorrectCnt+IruVerifyCnt] Fdc.IruSafeSwitchVerifyCnt"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "[ ] Fdc.SpareWord"
+
+  .AngleGlitchThr[1]:
+    @datatype: dReal
+    @default: 0.11 * DEG_2_RAD
+    @description: "[rad, GYRA ] Fdc.AngleGlitchThr[0] [1.0 deg/sec slew req't]"
+
+  .AngleGlitchThr[2]:
+    @datatype: dReal
+    @default: 0.11 * DEG_2_RAD
+    @description: "[rad, GYRB ] Fdc.AngleGlitchThr[1]"
+
+  .AngleGlitchThr[3]:
+    @datatype: dReal
+    @default: 0.11 * DEG_2_RAD
+    @description: "[rad, GYRC ] Fdc.AngleGlitchThr[2]"
+
+  .AngleGlitchThr[4]:
+    @datatype: dReal
+    @default: 0.11 * DEG_2_RAD
+    @description: "[rad, GYRD ] Fdc.AngleGlitchThr[3]"
+
+  .AccelGlitchThr[1]:
+    @datatype: dReal
+    @default: 0.017
+    @description: "[m/s, ACCA ] Fdc.AccelGlitchThr[0] [2 x BRE Capability at EOL]"
+
+  .AccelGlitchThr[2]:
+    @datatype: dReal
+    @default: 0.017
+    @description: "[m/s, ACCB ] Fdc.AccelGlitchThr[1]"
+
+  .AccelGlitchThr[3]:
+    @datatype: dReal
+    @default: 0.017
+    @description: "[m/s, ACCC ] Fdc.AccelGlitchThr[2]"
+
+  .AccelGlitchThr[4]:
+    @datatype: dReal
+    @default: 0.017
+    @description: "[m/s, ACCD ] Fdc.AccelGlitchThr[3]"
+
+  .ResonatorTempHiThr:
+    @datatype: dReal
+    @default: 80.0
+    @description: "[deg C ] Fdc.ResonatorTempHiThr"
+
+  .ResonatorTempLoThr:
+    @datatype: dReal
+    @default: 60.0
+    @description: "[deg C ] Fdc.ResonatorTempLoThr"
+
+}
+
+table ac_jet_table_type {
+  @buildstruct!
+  .ControlJet[1][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[1][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[1][3]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[1][4]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[1][5]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[1][6]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[1][7]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[1][8]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][3]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][4]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][5]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][6]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][7]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[2][8]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][1]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][2]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][3]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][4]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][5]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][6]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][7]:
+    @datatype: uWord
+    @default: NULL_JET
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[3][8]:
+    @datatype: uWord
+    @default: NULL_JET
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][3]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][4]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][5]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][6]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][7]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[4][8]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][3]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][4]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][5]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][6]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][7]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[5][8]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][3]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][4]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][5]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][6]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][7]:
+    @datatype: uWord
+    @default: NULL_JET
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[6][8]:
+    @datatype: uWord
+    @default: NULL_JET
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][3]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][4]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][5]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][6]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][7]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[7][8]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][1]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][2]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][3]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][4]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][5]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][6]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][7]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[8][8]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][1]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][2]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][3]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][4]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][5]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][6]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][7]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[9][8]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][1]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][2]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][3]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][4]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][5]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][6]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][7]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[10][8]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][1]:
+    @datatype: uWord
+    @default: REA2
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][2]:
+    @datatype: uWord
+    @default: REA8
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][3]:
+    @datatype: uWord
+    @default: REA12
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][4]:
+    @datatype: uWord
+    @default: REA6
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][5]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][6]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][7]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[11][8]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][1]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][3]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][4]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][5]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][6]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][7]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[12][8]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][1]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][3]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][4]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][5]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][6]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][7]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[13][8]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][1]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][3]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][4]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][5]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][6]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][7]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[14][8]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][1]:
+    @datatype: uWord
+    @default: REA10
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][3]:
+    @datatype: uWord
+    @default: REA4
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][4]:
+    @datatype: uWord
+    @default: REA1
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][5]:
+    @datatype: uWord
+    @default: REA3
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][6]:
+    @datatype: uWord
+    @default: REA5
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][7]:
+    @datatype: uWord
+    @default: REA9
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .ControlJet[15][8]:
+    @datatype: uWord
+    @default: REA11
+    @description: "ControlJet[15][8], ND PosDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[1][1]:
+    @datatype: uWord
+    @default: REA1
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[1][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[2][1]:
+    @datatype: uWord
+    @default: REA1
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[2][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[3][1]:
+    @datatype: uWord
+    @default: REA6
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[3][2]:
+    @datatype: uWord
+    @default: REA8
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[4][1]:
+    @datatype: uWord
+    @default: REA2
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[4][2]:
+    @datatype: uWord
+    @default: REA12
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[5][1]:
+    @datatype: uWord
+    @default: REA9
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[5][2]:
+    @datatype: uWord
+    @default: REA11
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[6][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[6][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[7][1]:
+    @datatype: uWord
+    @default: REA1
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[7][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[8][1]:
+    @datatype: uWord
+    @default: REA4
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .PosDeltaVJet[8][2]:
+    @datatype: uWord
+    @default: REA10
+    @description: "DV_REA_NEGZBDY NegDeltaVJet[8][2], ND"
+
+  .NegDeltaVJet[1][1]:
+    @datatype: uWord
+    @default: REA4
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[1][2]:
+    @datatype: uWord
+    @default: REA10
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[2][1]:
+    @datatype: uWord
+    @default: REA4
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[2][2]:
+    @datatype: uWord
+    @default: REA10
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[3][1]:
+    @datatype: uWord
+    @default: REA2
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[3][2]:
+    @datatype: uWord
+    @default: REA12
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[4][1]:
+    @datatype: uWord
+    @default: REA6
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[4][2]:
+    @datatype: uWord
+    @default: REA8
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[5][1]:
+    @datatype: uWord
+    @default: REA3
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[5][2]:
+    @datatype: uWord
+    @default: REA5
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[6][1]:
+    @datatype: uWord
+    @default: REA9
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[6][2]:
+    @datatype: uWord
+    @default: REA11
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[7][1]:
+    @datatype: uWord
+    @default: REA4
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[7][2]:
+    @datatype: uWord
+    @default: REA10
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[8][1]:
+    @datatype: uWord
+    @default: REA1
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .NegDeltaVJet[8][2]:
+    @datatype: uWord
+    @default: REA7
+    @description: "DV_REA_NEGZBDY ControlAxis[15][3], ND"
+
+  .ControlAxis[1][1]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[1][2]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[1][3]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[2][1]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[2][2]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[2][3]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[3][1]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[3][2]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[3][3]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[4][1]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[4][2]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[4][3]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[5][1]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[5][2]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[5][3]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[6][1]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[6][2]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[6][3]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[7][1]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[7][2]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[7][3]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[8][1]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[8][2]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[8][3]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[9][1]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[9][2]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[9][3]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[10][1]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[10][2]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[10][3]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[11][1]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[11][2]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[11][3]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[12][1]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[12][2]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[12][3]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[13][1]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[13][2]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[13][3]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[14][1]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[14][2]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[14][3]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .ControlAxis[15][1]:
+    @datatype: uWord
+    @default: X_AXIS
+
+  .ControlAxis[15][2]:
+    @datatype: uWord
+    @default: Y_AXIS
+
+  .ControlAxis[15][3]:
+    @datatype: uWord
+    @default: Z_AXIS
+
+  .MinNumOfLsb[1]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[2]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[3]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[4]:
+    @datatype: uWord
+    @default: 16
+    @description: "MinNumOfLsb[14], cnt"
+
+  .MinNumOfLsb[5]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[6]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[7]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[8]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[9]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[10]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[11]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[12]:
+    @datatype: uWord
+    @default: 16
+
+  .MinNumOfLsb[13]:
+    @datatype: uWord
+    @default: 50
+
+  .MinNumOfLsb[14]:
+    @datatype: uWord
+    @default: 50
+
+  .SustFireCnts:
+    @datatype: uWord
+    @default: 3
+    @description: "SustFireCnts, cnt Standby RateNull CSA CSP DeltaV Normal TgtPnt Mission EnableRwaTorqueMix[3][8], ND"
+
+  .EnableRwaTorqueMix[1][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[1][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[1][3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[1][4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[1][5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[1][6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[1][7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[1][8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][6]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[2][8]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][4]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][5]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][7]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Deployed"
+
+  .EnableRwaTorqueMix[3][8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "Deployed"
+
+  .DeltaVTransitionCnt:
+    @datatype: dword
+    @default: 10*NUM_AC_CYCLES
+    @description: "DeltaVTransitionCnt, cnt"
+
+  .EnableRiu2JetCmdInit:
+    @datatype: uWord
+    @default: FALSE
+    @description: "EnableRiu2JetCmdInit, ND"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .OffDelay[1]:
+    @datatype: dReal
+    @default: 0.012
+    @description: "OffDelay[14], sec"
+
+  .OffDelay[2]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[3]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[4]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[5]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[6]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[7]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[8]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[9]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[10]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[11]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[12]:
+    @datatype: dReal
+    @default: 0.012
+
+  .OffDelay[13]:
+    @datatype: dReal
+    @default: 0.0
+
+  .OffDelay[14]:
+    @datatype: dReal
+    @default: 0.0
+
+  .JetSecPerLsb:
+    @datatype: dReal
+    @default: 0.001
+    @description: "JetSecPerLsb, sec"
+
+  .JetSecondsRemainingThr:
+    @datatype: dReal
+    @default: 0.050
+    @description: "JetSecondsRemainingThr, sec"
+
+  .JetForceMag[1]:
+    @datatype: dReal
+    @default: 0.6735
+    @description: "JetForceMag[14], N"
+
+  .JetForceMag[2]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[3]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[4]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[5]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[6]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[7]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[8]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[9]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[10]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[11]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[12]:
+    @datatype: dReal
+    @default: 0.6735
+
+  .JetForceMag[13]:
+    @datatype: dReal
+    @default: 22.0454
+
+  .JetForceMag[14]:
+    @datatype: dReal
+    @default: 22.0454
+
+  .JetIsp[1]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetIsp[14], sec"
+
+  .JetIsp[2]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[3]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[4]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[5]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[6]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[7]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[8]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[9]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[10]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[11]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[12]:
+    @datatype: dReal
+    @default: 216.1127
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[13]:
+    @datatype: dReal
+    @default: 312.7700
+    @description: "JetNormTorq[14][3], m"
+
+  .JetIsp[14]:
+    @datatype: dReal
+    @default: 312.7700
+    @description: "JetNormTorq[14][3], m"
+
+  .JetNormTorq[1][1]:
+    @datatype: dReal
+    @default: 0.4007
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[1][2]:
+    @datatype: dReal
+    @default: 0.6381
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[1][3]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[2][1]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[2][2]:
+    @datatype: dReal
+    @default: -0.9257
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[2][3]:
+    @datatype: dReal
+    @default: -0.4611
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[3][1]:
+    @datatype: dReal
+    @default: -0.8653
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[3][2]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[3][3]:
+    @datatype: dReal
+    @default: 0.6381
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[4][1]:
+    @datatype: dReal
+    @default: -0.4007
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[4][2]:
+    @datatype: dReal
+    @default: 0.6817
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[4][3]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[5][1]:
+    @datatype: dReal
+    @default: 0.3442
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[5][2]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[5][3]:
+    @datatype: dReal
+    @default: -0.6817
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[6][1]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[6][2]:
+    @datatype: dReal
+    @default: -0.4047
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[6][3]:
+    @datatype: dReal
+    @default: 0.4611
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[7][1]:
+    @datatype: dReal
+    @default: -0.3836
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[7][2]:
+    @datatype: dReal
+    @default: -0.6817
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[7][3]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[8][1]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[8][2]:
+    @datatype: dReal
+    @default: 0.9257
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[8][3]:
+    @datatype: dReal
+    @default: -0.4440
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[9][1]:
+    @datatype: dReal
+    @default: 0.8653
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[9][2]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[9][3]:
+    @datatype: dReal
+    @default: 0.6817
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[10][1]:
+    @datatype: dReal
+    @default: 0.3836
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[10][2]:
+    @datatype: dReal
+    @default: -0.6381
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[10][3]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[11][1]:
+    @datatype: dReal
+    @default: -0.3442
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[11][2]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[11][3]:
+    @datatype: dReal
+    @default: -0.6381
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[12][1]:
+    @datatype: dReal
+    @default: 0.0000
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[12][2]:
+    @datatype: dReal
+    @default: 0.4047
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[12][3]:
+    @datatype: dReal
+    @default: 0.4440
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[13][1]:
+    @datatype: dReal
+    @default: 0.0023
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[13][2]:
+    @datatype: dReal
+    @default: 0.0048
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[13][3]:
+    @datatype: dReal
+    @default: 0.0001
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[14][1]:
+    @datatype: dReal
+    @default: 0.0023
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[14][2]:
+    @datatype: dReal
+    @default: 0.0048
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetNormTorq[14][3]:
+    @datatype: dReal
+    @default: 0.0001
+    @description: "JetForceUnit[14][3], ND Keep REAs at Ideal Alignments to Avoid Undesirable Simplex Behavior"
+
+  .JetForceUnit[1][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[1][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[1][3]:
+    @datatype: dReal
+    @default: 1.0000
+
+  .JetForceUnit[2][1]:
+    @datatype: dReal
+    @default: 1.0000
+
+  .JetForceUnit[2][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[2][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[3][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[3][2]:
+    @datatype: dReal
+    @default: -1.0000
+
+  .JetForceUnit[3][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[4][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[4][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[4][3]:
+    @datatype: dReal
+    @default: -1.0000
+
+  .JetForceUnit[5][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[5][2]:
+    @datatype: dReal
+    @default: -1.0000
+
+  .JetForceUnit[5][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[6][1]:
+    @datatype: dReal
+    @default: -1.0000
+
+  .JetForceUnit[6][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[6][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[7][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[7][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[7][3]:
+    @datatype: dReal
+    @default: 1.0000
+
+  .JetForceUnit[8][1]:
+    @datatype: dReal
+    @default: -1.0000
+
+  .JetForceUnit[8][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[8][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[9][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[9][2]:
+    @datatype: dReal
+    @default: 1.0000
+
+  .JetForceUnit[9][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[10][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[10][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[10][3]:
+    @datatype: dReal
+    @default: -1.0000
+
+  .JetForceUnit[11][1]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[11][2]:
+    @datatype: dReal
+    @default: 1.0000
+
+  .JetForceUnit[11][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[12][1]:
+    @datatype: dReal
+    @default: 1.0000
+
+  .JetForceUnit[12][2]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[12][3]:
+    @datatype: dReal
+    @default: 0.0000
+
+  .JetForceUnit[13][1]:
+    @datatype: dReal
+    @default: -0.0213
+
+  .JetForceUnit[13][2]:
+    @datatype: dReal
+    @default: -0.0049
+
+  .JetForceUnit[13][3]:
+    @datatype: dReal
+    @default: 0.9998
+
+  .JetForceUnit[14][1]:
+    @datatype: dReal
+    @default: -0.0213
+
+  .JetForceUnit[14][2]:
+    @datatype: dReal
+    @default: -0.0049
+
+  .JetForceUnit[14][3]:
+    @datatype: dReal
+    @default: 0.9998
+
+  .ThetaErrThrBRE:
+    @datatype: uVector
+    @default: {{ 0.50*DEG_2_RAD, 0.50*DEG_2_RAD, 0.50*DEG_2_RAD }}
+    @description: "ThetaErrThrBRE, rad"
+
+  .ThetaErrThrREA:
+    @datatype: uVector
+    @default: {{ 0.25*DEG_2_RAD, 0.25*DEG_2_RAD, 0.25*DEG_2_RAD }}
+    @description: "ThetaErrThrREA, rad"
+
+  .OmegaErrThrBRE:
+    @datatype: uVector
+    @default: {{ 0.05*DEG_2_RAD, 0.05*DEG_2_RAD, 0.05*DEG_2_RAD }}
+    @description: "OmegaErrThrBRE, rad/sec"
+
+  .OmegaErrThrREA:
+    @datatype: uVector
+    @default: {{ 0.05*DEG_2_RAD, 0.05*DEG_2_RAD, 0.05*DEG_2_RAD }}
+    @description: "OmegaErrThrREA, rad/sec"
+
+  .InitDeltaVTrqBiasScaleFactorBRE:
+    @datatype: dReal
+    @default: 0.50
+    @description: "InitDeltaVTrqBiasScaleFactorBRE"
+
+  .InitDeltaVTrqBiasScaleFactorREA:
+    @datatype: dReal
+    @default: 0.20
+    @description: "InitDeltaVTrqBiasScaleFactorREA"
+
+  .ResDeltaVTrqBiasScaleFactorBRE:
+    @datatype: dReal
+    @default: 1.30
+    @description: "ResDeltaVTrqBiasScaleFactorBRE"
+
+  .ResDeltaVTrqBiasScaleFactorREA:
+    @datatype: dReal
+    @default: 1.50
+    @description: "ResDeltaVTrqBiasScaleFactorREA"
+
+  .ResDeltaVIntErrScaleFactorBRE:
+    @datatype: dReal
+    @default: 0.60
+    @description: "ResDeltaVIntErrScaleFactorBRE"
+
+  .ResDeltaVIntErrScaleFactorREA:
+    @datatype: dReal
+    @default: 1.50
+    @description: "ResDeltaVIntErrScaleFactorREA"
+
+  .ResSimplexDeltaVIntErrGain:
+    @datatype: dReal
+    @default: 1.0
+    @description: "ResSimplexDeltaVIntErrGain"
+
+  .MinDeltaVCmdMag:
+    @datatype: dReal
+    @default: 0.001
+    @description: "MinDeltaVCmdMag, m/sec"
+
+  .MinBreDeltaVOnTime:
+    @datatype: dReal
+    @default: 10.0
+    @description: "MinBreDeltaVOnTime, sec"
+
+  .DeltaVTimerScaleFactor:
+    @datatype: dReal
+    @default: 2.0
+    @description: "DeltaVTimerScaleFactor"
+
+  .DeltaVTimerMinTimeEst:
+    @datatype: dReal
+    @default: 72.0
+    @description: "DeltaVTimerMinTimeEst, sec"
+
+  .SimplexTorqueSlewLmt:
+    @datatype: dReal
+    @default: 0.62969
+    @description: "SimplexTorqueSlewLmt - Ref: http://vasvn/svn/Seraphim/tools/thrusterAnalysis/DN117/Torque_maps r2145, taSimplex.m (rev C BOL)"
+
+  .PseudoInvTorqueSlewLmt:
+    @datatype: dReal
+    @default: 0.21784
+    @description: "PseudoInvTorqueSlewLmt - Ref: http://vasvn/svn/Seraphim/tools/thrusterAnalysis/DN117/Torque_maps r2145, taPseudo.m (rev C EOL)"
+
+  .MaxBurnDurationSF:
+    @datatype: dReal
+    @default: 2
+    @description: "MaxBurnDurationSF"
+
+  .UpperBoundLmt:
+    @datatype: dReal
+    @default: 2.0
+    @description: "UpperBoundLmt"
+
+  .ForceScaleFactorDefaultCost:
+    @datatype: dReal
+    @default: -10.0
+    @description: "ForceScaleFactorDefaultCost"
+
+  .TorqueScaleFactorDefaultCost:
+    @datatype: dReal
+    @default: -10.0
+    @description: "TorqueScaleFactorDefaultCost"
+
+  .ForceCmdBdyLmt:
+    @datatype: dReal
+    @default: 1.0
+    @description: "Force Command Limit, N"
+
+  .JetInSimplex[1]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[2]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[3]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "JetInSimplex[12]"
+
+  .JetInSimplex[5]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[6]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[7]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[8]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[9]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[10]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[11]:
+    @datatype: uWord
+    @default: TRUE
+
+  .JetInSimplex[12]:
+    @datatype: uWord
+    @default: TRUE
+
+  .InitialBasisVariables[1]:
+    @datatype: uWord
+    @default: REA1
+    @description: "InitialBasisVariables[6]"
+
+  .InitialBasisVariables[2]:
+    @datatype: uWord
+    @default: REA2
+    @description: "InitialBasisVariables[6]"
+
+  .InitialBasisVariables[3]:
+    @datatype: uWord
+    @default: REA3
+    @description: "InitialBasisVariables[6]"
+
+  .InitialBasisVariables[4]:
+    @datatype: uWord
+    @default: REA4
+    @description: "InitialBasisVariables[6]"
+
+  .InitialBasisVariables[5]:
+    @datatype: uWord
+    @default: REA8
+    @description: "InitialBasisVariables[6]"
+
+  .InitialBasisVariables[6]:
+    @datatype: uWord
+    @default: REA10
+    @description: "InitialBasisVariables[6]"
+
+  .InitialNonBasisVariables[1]:
+    @datatype: uWord
+    @default: REA5
+    @description: "InitialNonBasisVariables[8]"
+
+  .InitialNonBasisVariables[2]:
+    @datatype: uWord
+    @default: REA6
+    @description: "InitialNonBasisVariables[8]"
+
+  .InitialNonBasisVariables[3]:
+    @datatype: uWord
+    @default: REA7
+    @description: "InitialNonBasisVariables[8]"
+
+  .InitialNonBasisVariables[4]:
+    @datatype: uWord
+    @default: REA9
+    @description: "InitialNonBasisVariables[8]"
+
+  .InitialNonBasisVariables[5]:
+    @datatype: uWord
+    @default: REA11
+    @description: "InitialNonBasisVariables[8]"
+
+  .InitialNonBasisVariables[6]:
+    @datatype: uWord
+    @default: REA12
+    @description: "InitialNonBasisVariables[8]"
+
+  .InitialNonBasisVariables[7]:
+    @datatype: uWord
+    @default: FORCE_SF_INDEX
+    @description: "InitialNonBasisVariables[8]"
+
+  .InitialNonBasisVariables[8]:
+    @datatype: uWord
+    @default: TORQUE_SF_INDEX
+    @description: "InitialNonBasisVariables[8]"
+
+  .SimplexIterationLmt:
+    @datatype: uWord
+    @default: 100
+    @description: "SimplexInterationLmt, cnt"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .DeltaVThrSetForMnvMgrCmd:
+    @datatype: uWord
+    @default: DV_BRE_PRI
+    @description: "DeltaVThrSetForMnvMgrCmd, ac_dv_id_type"
+
+  .ControlThrSetForMnvMgrCmd:
+    @datatype: uWord
+    @default: CNT_MED_TORQUE
+    @description: "ControlThrSetForMnvMgrCmd, ac_cnt_id_type"
+
+  .ReaTurnToBurnThrSet:
+    @datatype: uWord
+    @default: DV_REA_POSZBDY
+    @description: "ReaTurnToBurnThrSet , ac_dv_id_type"
+
+  .SpareWord1:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord1"
+
+}
+
+table ac_lunar_table_type {
+  @buildstruct!
+  .LML1:
+    @datatype: dReal
+    @default: 218.32 * DEG_2_RAD
+    @description: "[rad ] LML1"
+
+  .LML2:
+    @datatype: dReal
+    @default: 481267.883 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad ] LML2"
+
+  .LML3:
+    @datatype: dReal
+    @default: 6.29 * DEG_2_RAD
+    @description: "[rad ] LML3"
+
+  .LML4:
+    @datatype: dReal
+    @default: 1.27 * DEG_2_RAD
+    @description: "[rad ] LML4"
+
+  .LML5:
+    @datatype: dReal
+    @default: 0.66 * DEG_2_RAD
+    @description: "[rad ] LML5"
+
+  .LML6:
+    @datatype: dReal
+    @default: 0.21 * DEG_2_RAD
+    @description: "[rad ] LML6"
+
+  .LML7:
+    @datatype: dReal
+    @default: 0.19 * DEG_2_RAD
+    @description: "[rad ] LML7"
+
+  .LML8:
+    @datatype: dReal
+    @default: 0.11 * DEG_2_RAD
+    @description: "[rad ] LML8"
+
+  .LMLP1:
+    @datatype: dReal
+    @default: 134.9 * DEG_2_RAD
+    @description: "[rad ] LMLP1"
+
+  .LMLP2:
+    @datatype: dReal
+    @default: 259.2 * DEG_2_RAD
+    @description: "[rad ] LMLP2"
+
+  .LMLP3:
+    @datatype: dReal
+    @default: 235.7 * DEG_2_RAD
+    @description: "[rad ] LMLP3"
+
+  .LMLP4:
+    @datatype: dReal
+    @default: 269.9 * DEG_2_RAD
+    @description: "[rad ] LMLP4"
+
+  .LMLP5:
+    @datatype: dReal
+    @default: 357.5 * DEG_2_RAD
+    @description: "[rad ] LMLP5"
+
+  .LMLP6:
+    @datatype: dReal
+    @default: 186.6 * DEG_2_RAD
+    @description: "[rad ] LMLP6"
+
+  .LMLW1:
+    @datatype: dReal
+    @default: 477198.85 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMLW1"
+
+  .LMLW2:
+    @datatype: dReal
+    @default: 413335.38 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMLW2"
+
+  .LMLW3:
+    @datatype: dReal
+    @default: 890534.23 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMLW3"
+
+  .LMLW4:
+    @datatype: dReal
+    @default: 954397.70 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMLW4"
+
+  .LMLW5:
+    @datatype: dReal
+    @default: 35999.05 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMLW5"
+
+  .LMLW6:
+    @datatype: dReal
+    @default: 966404.05 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMLW6"
+
+  .LMB1:
+    @datatype: dReal
+    @default: 5.13 * DEG_2_RAD
+    @description: "[rad ] LMB1"
+
+  .LMB2:
+    @datatype: dReal
+    @default: 0.28 * DEG_2_RAD
+    @description: "[rad ] LMB2"
+
+  .LMB3:
+    @datatype: dReal
+    @default: 0.28 * DEG_2_RAD
+    @description: "[rad ] LMB3"
+
+  .LMB4:
+    @datatype: dReal
+    @default: 0.17 * DEG_2_RAD
+    @description: "[rad ] LMB4"
+
+  .LMBP1:
+    @datatype: dReal
+    @default: 93.3 * DEG_2_RAD
+    @description: "[rad ] LMBP1"
+
+  .LMBP2:
+    @datatype: dReal
+    @default: 228.2 * DEG_2_RAD
+    @description: "[rad ] LMBP2"
+
+  .LMBP3:
+    @datatype: dReal
+    @default: 318.3 * DEG_2_RAD
+    @description: "[rad ] LMBP3"
+
+  .LMBP4:
+    @datatype: dReal
+    @default: 217.6 * DEG_2_RAD
+    @description: "[rad ] LMBP4"
+
+  .LMBW1:
+    @datatype: dReal
+    @default: 483202.03 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMBW1"
+
+  .LMBW2:
+    @datatype: dReal
+    @default: 960400.87 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMBW2"
+
+  .LMBW3:
+    @datatype: dReal
+    @default: 6003.18 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMBW3"
+
+  .LMBW4:
+    @datatype: dReal
+    @default: 407332.20 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMBW4"
+
+  .LMC1:
+    @datatype: dReal
+    @default: 0.9175
+    @description: "[ND ] LMC1"
+
+  .LMC2:
+    @datatype: dReal
+    @default: 0.3978
+    @description: "[ND ] LMC2"
+
+  .LMC3:
+    @datatype: dReal
+    @default: 0.3978
+    @description: "[ND ] LMC3"
+
+  .LMC4:
+    @datatype: dReal
+    @default: 0.9175
+    @description: "[ND ] LMC4"
+
+  .LMP1:
+    @datatype: dReal
+    @default: 0.9508 * DEG_2_RAD
+    @description: "[rad ] LMP1"
+
+  .LMP2:
+    @datatype: dReal
+    @default: 0.0518 * DEG_2_RAD
+    @description: "[rad ] LMP2"
+
+  .LMP3:
+    @datatype: dReal
+    @default: 0.0095 * DEG_2_RAD
+    @description: "[rad ] LMP3"
+
+  .LMP4:
+    @datatype: dReal
+    @default: 0.0078 * DEG_2_RAD
+    @description: "[rad ] LMP4"
+
+  .LMP5:
+    @datatype: dReal
+    @default: 0.0028 * DEG_2_RAD
+    @description: "[rad ] LMP5"
+
+  .LMPP1:
+    @datatype: dReal
+    @default: 134.9 * DEG_2_RAD
+    @description: "[rad ] LMPP1"
+
+  .LMPP2:
+    @datatype: dReal
+    @default: 259.2 * DEG_2_RAD
+    @description: "[rad ] LMPP2"
+
+  .LMPP3:
+    @datatype: dReal
+    @default: 235.7 * DEG_2_RAD
+    @description: "[rad ] LMPP3"
+
+  .LMPP4:
+    @datatype: dReal
+    @default: 269.9 * DEG_2_RAD
+    @description: "[rad ] LMPP4"
+
+  .LMPW1:
+    @datatype: dReal
+    @default: 477198.85 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMPW1"
+
+  .LMPW2:
+    @datatype: dReal
+    @default: 413335.38 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMPW2"
+
+  .LMPW3:
+    @datatype: dReal
+    @default: 890534.23 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMPW3"
+
+  .LMPW4:
+    @datatype: dReal
+    @default: 954397.70 * DEG_2_RAD / CENTURY_2_DAY
+    @description: "[rad/jd ] LMPW4"
+
+  .RE0:
+    @datatype: dReal
+    @default: 6378136.6
+    @description: "[m ] RE0"
+
+}
+
+table ac_mode_table_type {
+  @buildstruct!
+  .Mode[1][1]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[1][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[1][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[1][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[1][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[1][6]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[1][7]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[1][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][3]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][4]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][5]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[2][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][1]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][2]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][4]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][5]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][6]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][7]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[3][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][1]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][3]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][5]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][6]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][7]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[4][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][1]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][4]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[5][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][4]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][5]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][6]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[6][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][1]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][6]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][7]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[7][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][1]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][7]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Mode[8][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "AcModeTable.Mode[RequestedMode][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedMode_ Mission AcModeTable.Att[RequestedAtt][CurrentMode] S RN SAQ SPt DV Nml Tgt M _RequestedAtt_"
+
+  .Att[1][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[1][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[1][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[1][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[1][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[1][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[1][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[1][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[2][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[2][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[2][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[2][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[2][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[2][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[2][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[2][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[3][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[3][2]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[3][3]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[3][4]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[3][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[3][6]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[3][7]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[3][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[4][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[4][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[4][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[4][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[4][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[4][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[4][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[4][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[5][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[5][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[5][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[5][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[5][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[5][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[5][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[5][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[6][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[6][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[6][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[6][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[6][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[6][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[6][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[6][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[7][1]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[7][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[7][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[7][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[7][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[7][6]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[7][7]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[7][8]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[8][1]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[8][2]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[8][3]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[8][4]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[8][5]:
+    @datatype: uByte
+    @default: 0
+    @description: "SunEph"
+
+  .Att[8][6]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[8][7]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+  .Att[8][8]:
+    @datatype: uByte
+    @default: 1
+    @description: "SunEph"
+
+}
+
+table ac_mpl_table_type {
+  @buildstruct!
+  .IscAzAngle:
+    @datatype: dReal
+    @default: (90.0 * DEG_2_RAD)
+    @description: "IscAzAngle, rad"
+
+  .IscElAngle:
+    @datatype: dReal
+    @default: (0.0 * DEG_2_RAD)
+    @description: "IscElAngle, rad"
+
+  .IazLocal:
+    @datatype: uMatrix
+    @default: {{{ 12.05927, -0.10415, 3.28974 }, { -0.10415, 19.76431, 0.04727 }, { 3.28974, 0.04727, 9.20206 }}}
+
+  .IelLocal:
+    @datatype: uMatrix
+    @default: {{{ 26.25555, 0.31184, -1.33969 }, { 0.31184, 29.28359, -2.10382 }, { -1.33969, -2.10382, 10.63511 }}}
+
+  .MassAz:
+    @datatype: dReal
+    @default: 73.672
+    @description: "MassAz, kg , Mass Props Rev E"
+
+  .MassEl:
+    @datatype: dReal
+    @default: 110.944
+    @description: "MassEl, kg , Mass Props Rev E"
+
+  .AzCmLocal:
+    @datatype: uVector
+    @default: { -0.07049, 0.00000, 0.28360 }
+    @description: "AzCmLocal (m), Mass Props Rev E"
+
+  .ElCmLocal:
+    @datatype: uVector
+    @default: { 0.04680, 0.00000, -0.00001 }
+    @description: "ElCmLocal (m), Mass Props Rev E"
+
+  .AzFrameAttach:
+    @datatype: uVector
+    @default: { 0.00000, 0.00000, 1.83388 }
+    @description: "AzFrameAttach (m), Mass Props Rev E"
+
+  .ElFrameAttach:
+    @datatype: uVector
+    @default: { 0.00000, 0.00000, 0.92443 }
+    @description: "ElFrameAttach (m), Mass Props Rev E"
+
+}
+
+table ac_rwa_table_type {
+  @buildstruct!
+  .Inertia[1]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "Teldix RDR-12 Nominal Inertia Inertia, Nms^2 RWA1 (SV_ID=1)"
+
+  .Inertia[2]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA2 (SV_ID=1)"
+
+  .Inertia[3]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA3 (SV_ID=1)"
+
+  .Inertia[4]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA4 (SV_ID=1)"
+
+  .DcmRwaToBdy[1][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[1][2]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[1][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[1][4]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[2][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[2][2]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[2][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[2][4]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[3][1]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[3][2]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[3][3]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmRwaToBdy[3][4]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=1)"
+
+  .DcmBdyToRwa[1][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[1][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[1][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[2][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[2][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[2][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[3][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[3][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[3][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[4][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[4][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToRwa[4][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=1)"
+
+  .NullSpace[1]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=1)"
+
+  .NullSpace[2]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=1)"
+
+  .NullSpace[3]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=1)"
+
+  .NullSpace[4]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=1)"
+
+  .NumOfRwaTachCycles:
+    @datatype: uWord
+    @default: 6*NUM_AC_CYCLES
+    @description: "NumOfRwaTachCycles, cnt (SV_ID=1)"
+
+  .MaxTachCountValue:
+    @datatype: uWord
+    @default: 16383
+    @description: "MaxTachCountValue, 0x3FFF, cnt (SV_ID=1)"
+
+  .DeltaTachCountThr:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaTachCountThr, cnt (SV_ID=1)"
+
+  .Pad:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding for alignment (SV_ID=1)"
+
+  .Pulse2Angle:
+    @datatype: dReal
+    @default: TWO_PI / 24.0
+    @description: "Teldix Pulse2Angle, rad/pulse, 75119-801_C_Interface_Control_Document 4.4.5.3 (SV_ID=1)"
+
+  .Torque2VoltSF[1]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=1)"
+
+  .Torque2VoltSF[2]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=1)"
+
+  .Torque2VoltSF[3]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=1)"
+
+  .Torque2VoltSF[4]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=1)"
+
+  .Torque2VoltBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=1)"
+
+  .Torque2VoltBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=1)"
+
+  .Torque2VoltBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=1)"
+
+  .Torque2VoltBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=1)"
+
+  .CmdVolt2CntBias:
+    @datatype: dReal
+    @default: 0
+    @description: "CmdVolt2CntBias, cnt (SV_ID=1)"
+
+  .CmdVolt2CntSF:
+    @datatype: dReal
+    @default: 204.8
+    @description: "CmdVolt2CntSF, cnt/V (SV_ID=1)"
+
+  .TorqueSlewLmt[1]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=1)"
+
+  .TorqueSlewLmt[2]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=1)"
+
+  .TorqueSlewLmt[3]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=1)"
+
+  .TorqueSlewLmt[4]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=1)"
+
+  .TorqueCmdMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=1)"
+
+  .TorqueCmdMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=1)"
+
+  .TorqueCmdMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=1)"
+
+  .TorqueCmdMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=1)"
+
+  .TorqueScNullCtlMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=1)"
+
+  .TorqueScNullCtlMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=1)"
+
+  .TorqueScNullCtlMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=1)"
+
+  .TorqueScNullCtlMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=1)"
+
+  .BiasSpeedGain:
+    @datatype: dReal
+    @default: 1.6E-05
+    @description: "BiasSpeedGain, Nm/(rad/sec) (SV_ID=1)"
+
+  .BiasSpeedTorqueLmt:
+    @datatype: dReal
+    @default: 0.030
+    @description: "BiasSpeedTorqueLmt, Nm (SV_ID=1)"
+
+  .DefaultSpeedCmd[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=1)"
+
+  .DefaultSpeedCmd[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=1)"
+
+  .DefaultSpeedCmd[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=1)"
+
+  .DefaultSpeedCmd[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=1)"
+
+  .SpeedCmdMax:
+    @datatype: dReal
+    @default: 6000.0*RPM_2_RPS
+    @description: "Teldix SpeedCmdMax, rad/sec, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1 (SV_ID=1)"
+
+  .ViscousFrcSF[1]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "ViscousFrcSF, Nm/(rad/sec) RWA1 (SV_ID=1)"
+
+  .ViscousFrcSF[2]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA2 (SV_ID=1)"
+
+  .ViscousFrcSF[3]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA3 (SV_ID=1)"
+
+  .ViscousFrcSF[4]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA4 (SV_ID=1)"
+
+  .Kest[1]:
+    @datatype: dReal
+    @default: 2.10E-1
+    @description: "Teldix Kest (SV_ID=1)"
+
+  .Kest[2]:
+    @datatype: dReal
+    @default: 2.74E-4
+    @description: "Teldix Kest (SV_ID=1)"
+
+  .Kcnt[1]:
+    @datatype: dReal
+    @default: 0.071
+    @description: "Teldix Kcnt (SV_ID=1)"
+
+  .Kcnt[2]:
+    @datatype: dReal
+    @default: 1.00
+    @description: "Teldix Kcnt (SV_ID=1)"
+
+  .TorqueStictionMax[1]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=1)"
+
+  .TorqueStictionMax[2]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=1)"
+
+  .TorqueStictionMax[3]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=1)"
+
+  .TorqueStictionMax[4]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=1)"
+
+  .PowerStatusOffCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=1)"
+
+  .PowerStatusOffCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=1)"
+
+  .PowerStatusOffCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=1)"
+
+  .PowerStatusOffCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=1)"
+
+  .SpeedErrCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=1)"
+
+  .SpeedErrCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=1)"
+
+  .SpeedErrCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=1)"
+
+  .SpeedErrCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=1)"
+
+  .RwaCorrectCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "RwaCorrectCnt, cnt (SV_ID=1)"
+
+  .RwaVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "RwaVerifyCnt, cnt (SV_ID=1)"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=1)"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=1)"
+
+  .SpeedErrThr[1]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=1)"
+
+  .SpeedErrThr[2]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=1)"
+
+  .SpeedErrThr[3]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=1)"
+
+  .SpeedErrThr[4]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=1)"
+
+  .Inertia[1]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "Teldix RDR-12 Nominal Inertia Inertia, Nms^2 RWA1 (SV_ID=2)"
+
+  .Inertia[2]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA2 (SV_ID=2)"
+
+  .Inertia[3]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA3 (SV_ID=2)"
+
+  .Inertia[4]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA4 (SV_ID=2)"
+
+  .DcmRwaToBdy[1][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[1][2]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[1][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[1][4]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[2][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[2][2]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[2][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[2][4]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[3][1]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[3][2]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[3][3]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmRwaToBdy[3][4]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=2)"
+
+  .DcmBdyToRwa[1][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[1][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[1][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[2][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[2][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[2][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[3][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[3][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[3][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[4][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[4][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToRwa[4][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=2)"
+
+  .NullSpace[1]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=2)"
+
+  .NullSpace[2]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=2)"
+
+  .NullSpace[3]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=2)"
+
+  .NullSpace[4]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=2)"
+
+  .NumOfRwaTachCycles:
+    @datatype: uWord
+    @default: 6*NUM_AC_CYCLES
+    @description: "NumOfRwaTachCycles, cnt (SV_ID=2)"
+
+  .MaxTachCountValue:
+    @datatype: uWord
+    @default: 16383
+    @description: "MaxTachCountValue, 0x3FFF, cnt (SV_ID=2)"
+
+  .DeltaTachCountThr:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaTachCountThr, cnt (SV_ID=2)"
+
+  .Pad:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding for alignment (SV_ID=2)"
+
+  .Pulse2Angle:
+    @datatype: dReal
+    @default: TWO_PI / 24.0
+    @description: "Teldix Pulse2Angle, rad/pulse, 75119-801_C_Interface_Control_Document 4.4.5.3 (SV_ID=2)"
+
+  .Torque2VoltSF[1]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=2)"
+
+  .Torque2VoltSF[2]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=2)"
+
+  .Torque2VoltSF[3]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=2)"
+
+  .Torque2VoltSF[4]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=2)"
+
+  .Torque2VoltBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=2)"
+
+  .Torque2VoltBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=2)"
+
+  .Torque2VoltBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=2)"
+
+  .Torque2VoltBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=2)"
+
+  .CmdVolt2CntBias:
+    @datatype: dReal
+    @default: 0
+    @description: "CmdVolt2CntBias, cnt (SV_ID=2)"
+
+  .CmdVolt2CntSF:
+    @datatype: dReal
+    @default: 204.8
+    @description: "CmdVolt2CntSF, cnt/V (SV_ID=2)"
+
+  .TorqueSlewLmt[1]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=2)"
+
+  .TorqueSlewLmt[2]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=2)"
+
+  .TorqueSlewLmt[3]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=2)"
+
+  .TorqueSlewLmt[4]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=2)"
+
+  .TorqueCmdMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=2)"
+
+  .TorqueCmdMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=2)"
+
+  .TorqueCmdMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=2)"
+
+  .TorqueCmdMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=2)"
+
+  .TorqueScNullCtlMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=2)"
+
+  .TorqueScNullCtlMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=2)"
+
+  .TorqueScNullCtlMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=2)"
+
+  .TorqueScNullCtlMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=2)"
+
+  .BiasSpeedGain:
+    @datatype: dReal
+    @default: 1.6E-05
+    @description: "BiasSpeedGain, Nm/(rad/sec) (SV_ID=2)"
+
+  .BiasSpeedTorqueLmt:
+    @datatype: dReal
+    @default: 0.030
+    @description: "BiasSpeedTorqueLmt, Nm (SV_ID=2)"
+
+  .DefaultSpeedCmd[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=2)"
+
+  .DefaultSpeedCmd[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=2)"
+
+  .DefaultSpeedCmd[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=2)"
+
+  .DefaultSpeedCmd[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=2)"
+
+  .SpeedCmdMax:
+    @datatype: dReal
+    @default: 6000.0*RPM_2_RPS
+    @description: "Teldix SpeedCmdMax, rad/sec, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1 (SV_ID=2)"
+
+  .ViscousFrcSF[1]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "ViscousFrcSF, Nm/(rad/sec) RWA1 (SV_ID=2)"
+
+  .ViscousFrcSF[2]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA2 (SV_ID=2)"
+
+  .ViscousFrcSF[3]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA3 (SV_ID=2)"
+
+  .ViscousFrcSF[4]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA4 (SV_ID=2)"
+
+  .Kest[1]:
+    @datatype: dReal
+    @default: 2.10E-1
+    @description: "Teldix Kest (SV_ID=2)"
+
+  .Kest[2]:
+    @datatype: dReal
+    @default: 2.74E-4
+    @description: "Teldix Kest (SV_ID=2)"
+
+  .Kcnt[1]:
+    @datatype: dReal
+    @default: 0.071
+    @description: "Teldix Kcnt (SV_ID=2)"
+
+  .Kcnt[2]:
+    @datatype: dReal
+    @default: 1.00
+    @description: "Teldix Kcnt (SV_ID=2)"
+
+  .TorqueStictionMax[1]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=2)"
+
+  .TorqueStictionMax[2]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=2)"
+
+  .TorqueStictionMax[3]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=2)"
+
+  .TorqueStictionMax[4]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=2)"
+
+  .PowerStatusOffCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=2)"
+
+  .PowerStatusOffCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=2)"
+
+  .PowerStatusOffCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=2)"
+
+  .PowerStatusOffCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=2)"
+
+  .SpeedErrCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=2)"
+
+  .SpeedErrCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=2)"
+
+  .SpeedErrCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=2)"
+
+  .SpeedErrCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=2)"
+
+  .RwaCorrectCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "RwaCorrectCnt, cnt (SV_ID=2)"
+
+  .RwaVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "RwaVerifyCnt, cnt (SV_ID=2)"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=2)"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=2)"
+
+  .SpeedErrThr[1]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=2)"
+
+  .SpeedErrThr[2]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=2)"
+
+  .SpeedErrThr[3]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=2)"
+
+  .SpeedErrThr[4]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=2)"
+
+  .Inertia[1]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "Teldix RDR-12 Nominal Inertia Inertia, Nms^2 RWA1 (SV_ID=3)"
+
+  .Inertia[2]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA2 (SV_ID=3)"
+
+  .Inertia[3]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA3 (SV_ID=3)"
+
+  .Inertia[4]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA4 (SV_ID=3)"
+
+  .DcmRwaToBdy[1][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[1][2]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[1][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[1][4]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[2][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[2][2]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[2][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[2][4]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[3][1]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[3][2]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[3][3]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmRwaToBdy[3][4]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=3)"
+
+  .DcmBdyToRwa[1][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[1][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[1][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[2][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[2][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[2][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[3][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[3][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[3][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[4][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[4][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToRwa[4][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=3)"
+
+  .NullSpace[1]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=3)"
+
+  .NullSpace[2]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=3)"
+
+  .NullSpace[3]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=3)"
+
+  .NullSpace[4]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=3)"
+
+  .NumOfRwaTachCycles:
+    @datatype: uWord
+    @default: 6*NUM_AC_CYCLES
+    @description: "NumOfRwaTachCycles, cnt (SV_ID=3)"
+
+  .MaxTachCountValue:
+    @datatype: uWord
+    @default: 16383
+    @description: "MaxTachCountValue, 0x3FFF, cnt (SV_ID=3)"
+
+  .DeltaTachCountThr:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaTachCountThr, cnt (SV_ID=3)"
+
+  .Pad:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding for alignment (SV_ID=3)"
+
+  .Pulse2Angle:
+    @datatype: dReal
+    @default: TWO_PI / 24.0
+    @description: "Teldix Pulse2Angle, rad/pulse, 75119-801_C_Interface_Control_Document 4.4.5.3 (SV_ID=3)"
+
+  .Torque2VoltSF[1]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=3)"
+
+  .Torque2VoltSF[2]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=3)"
+
+  .Torque2VoltSF[3]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=3)"
+
+  .Torque2VoltSF[4]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=3)"
+
+  .Torque2VoltBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=3)"
+
+  .Torque2VoltBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=3)"
+
+  .Torque2VoltBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=3)"
+
+  .Torque2VoltBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=3)"
+
+  .CmdVolt2CntBias:
+    @datatype: dReal
+    @default: 0
+    @description: "CmdVolt2CntBias, cnt (SV_ID=3)"
+
+  .CmdVolt2CntSF:
+    @datatype: dReal
+    @default: 204.8
+    @description: "CmdVolt2CntSF, cnt/V (SV_ID=3)"
+
+  .TorqueSlewLmt[1]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=3)"
+
+  .TorqueSlewLmt[2]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=3)"
+
+  .TorqueSlewLmt[3]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=3)"
+
+  .TorqueSlewLmt[4]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=3)"
+
+  .TorqueCmdMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=3)"
+
+  .TorqueCmdMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=3)"
+
+  .TorqueCmdMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=3)"
+
+  .TorqueCmdMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=3)"
+
+  .TorqueScNullCtlMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=3)"
+
+  .TorqueScNullCtlMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=3)"
+
+  .TorqueScNullCtlMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=3)"
+
+  .TorqueScNullCtlMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=3)"
+
+  .BiasSpeedGain:
+    @datatype: dReal
+    @default: 1.6E-05
+    @description: "BiasSpeedGain, Nm/(rad/sec) (SV_ID=3)"
+
+  .BiasSpeedTorqueLmt:
+    @datatype: dReal
+    @default: 0.030
+    @description: "BiasSpeedTorqueLmt, Nm (SV_ID=3)"
+
+  .DefaultSpeedCmd[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=3)"
+
+  .DefaultSpeedCmd[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=3)"
+
+  .DefaultSpeedCmd[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=3)"
+
+  .DefaultSpeedCmd[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=3)"
+
+  .SpeedCmdMax:
+    @datatype: dReal
+    @default: 6000.0*RPM_2_RPS
+    @description: "Teldix SpeedCmdMax, rad/sec, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1 (SV_ID=3)"
+
+  .ViscousFrcSF[1]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "ViscousFrcSF, Nm/(rad/sec) RWA1 (SV_ID=3)"
+
+  .ViscousFrcSF[2]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA2 (SV_ID=3)"
+
+  .ViscousFrcSF[3]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA3 (SV_ID=3)"
+
+  .ViscousFrcSF[4]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA4 (SV_ID=3)"
+
+  .Kest[1]:
+    @datatype: dReal
+    @default: 2.10E-1
+    @description: "Teldix Kest (SV_ID=3)"
+
+  .Kest[2]:
+    @datatype: dReal
+    @default: 2.74E-4
+    @description: "Teldix Kest (SV_ID=3)"
+
+  .Kcnt[1]:
+    @datatype: dReal
+    @default: 0.071
+    @description: "Teldix Kcnt (SV_ID=3)"
+
+  .Kcnt[2]:
+    @datatype: dReal
+    @default: 1.00
+    @description: "Teldix Kcnt (SV_ID=3)"
+
+  .TorqueStictionMax[1]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=3)"
+
+  .TorqueStictionMax[2]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=3)"
+
+  .TorqueStictionMax[3]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=3)"
+
+  .TorqueStictionMax[4]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=3)"
+
+  .PowerStatusOffCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=3)"
+
+  .PowerStatusOffCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=3)"
+
+  .PowerStatusOffCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=3)"
+
+  .PowerStatusOffCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=3)"
+
+  .SpeedErrCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=3)"
+
+  .SpeedErrCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=3)"
+
+  .SpeedErrCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=3)"
+
+  .SpeedErrCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=3)"
+
+  .RwaCorrectCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "RwaCorrectCnt, cnt (SV_ID=3)"
+
+  .RwaVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "RwaVerifyCnt, cnt (SV_ID=3)"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=3)"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=3)"
+
+  .SpeedErrThr[1]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=3)"
+
+  .SpeedErrThr[2]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=3)"
+
+  .SpeedErrThr[3]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=3)"
+
+  .SpeedErrThr[4]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=3)"
+
+  .Inertia[1]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "Teldix RDR-12 Nominal Inertia Inertia, Nms^2 RWA1 (SV_ID=4)"
+
+  .Inertia[2]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA2 (SV_ID=4)"
+
+  .Inertia[3]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA3 (SV_ID=4)"
+
+  .Inertia[4]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA4 (SV_ID=4)"
+
+  .DcmRwaToBdy[1][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[1][2]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[1][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[1][4]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[2][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[2][2]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[2][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[2][4]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[3][1]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[3][2]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[3][3]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmRwaToBdy[3][4]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=4)"
+
+  .DcmBdyToRwa[1][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[1][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[1][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[2][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[2][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[2][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[3][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[3][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[3][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[4][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[4][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToRwa[4][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=4)"
+
+  .NullSpace[1]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=4)"
+
+  .NullSpace[2]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=4)"
+
+  .NullSpace[3]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=4)"
+
+  .NullSpace[4]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=4)"
+
+  .NumOfRwaTachCycles:
+    @datatype: uWord
+    @default: 6*NUM_AC_CYCLES
+    @description: "NumOfRwaTachCycles, cnt (SV_ID=4)"
+
+  .MaxTachCountValue:
+    @datatype: uWord
+    @default: 16383
+    @description: "MaxTachCountValue, 0x3FFF, cnt (SV_ID=4)"
+
+  .DeltaTachCountThr:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaTachCountThr, cnt (SV_ID=4)"
+
+  .Pad:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding for alignment (SV_ID=4)"
+
+  .Pulse2Angle:
+    @datatype: dReal
+    @default: TWO_PI / 24.0
+    @description: "Teldix Pulse2Angle, rad/pulse, 75119-801_C_Interface_Control_Document 4.4.5.3 (SV_ID=4)"
+
+  .Torque2VoltSF[1]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=4)"
+
+  .Torque2VoltSF[2]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=4)"
+
+  .Torque2VoltSF[3]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=4)"
+
+  .Torque2VoltSF[4]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=4)"
+
+  .Torque2VoltBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=4)"
+
+  .Torque2VoltBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=4)"
+
+  .Torque2VoltBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=4)"
+
+  .Torque2VoltBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=4)"
+
+  .CmdVolt2CntBias:
+    @datatype: dReal
+    @default: 0
+    @description: "CmdVolt2CntBias, cnt (SV_ID=4)"
+
+  .CmdVolt2CntSF:
+    @datatype: dReal
+    @default: 204.8
+    @description: "CmdVolt2CntSF, cnt/V (SV_ID=4)"
+
+  .TorqueSlewLmt[1]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=4)"
+
+  .TorqueSlewLmt[2]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=4)"
+
+  .TorqueSlewLmt[3]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=4)"
+
+  .TorqueSlewLmt[4]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=4)"
+
+  .TorqueCmdMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=4)"
+
+  .TorqueCmdMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=4)"
+
+  .TorqueCmdMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=4)"
+
+  .TorqueCmdMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=4)"
+
+  .TorqueScNullCtlMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=4)"
+
+  .TorqueScNullCtlMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=4)"
+
+  .TorqueScNullCtlMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=4)"
+
+  .TorqueScNullCtlMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=4)"
+
+  .BiasSpeedGain:
+    @datatype: dReal
+    @default: 1.6E-05
+    @description: "BiasSpeedGain, Nm/(rad/sec) (SV_ID=4)"
+
+  .BiasSpeedTorqueLmt:
+    @datatype: dReal
+    @default: 0.030
+    @description: "BiasSpeedTorqueLmt, Nm (SV_ID=4)"
+
+  .DefaultSpeedCmd[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=4)"
+
+  .DefaultSpeedCmd[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=4)"
+
+  .DefaultSpeedCmd[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=4)"
+
+  .DefaultSpeedCmd[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=4)"
+
+  .SpeedCmdMax:
+    @datatype: dReal
+    @default: 6000.0*RPM_2_RPS
+    @description: "Teldix SpeedCmdMax, rad/sec, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1 (SV_ID=4)"
+
+  .ViscousFrcSF[1]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "ViscousFrcSF, Nm/(rad/sec) RWA1 (SV_ID=4)"
+
+  .ViscousFrcSF[2]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA2 (SV_ID=4)"
+
+  .ViscousFrcSF[3]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA3 (SV_ID=4)"
+
+  .ViscousFrcSF[4]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA4 (SV_ID=4)"
+
+  .Kest[1]:
+    @datatype: dReal
+    @default: 2.10E-1
+    @description: "Teldix Kest (SV_ID=4)"
+
+  .Kest[2]:
+    @datatype: dReal
+    @default: 2.74E-4
+    @description: "Teldix Kest (SV_ID=4)"
+
+  .Kcnt[1]:
+    @datatype: dReal
+    @default: 0.071
+    @description: "Teldix Kcnt (SV_ID=4)"
+
+  .Kcnt[2]:
+    @datatype: dReal
+    @default: 1.00
+    @description: "Teldix Kcnt (SV_ID=4)"
+
+  .TorqueStictionMax[1]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=4)"
+
+  .TorqueStictionMax[2]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=4)"
+
+  .TorqueStictionMax[3]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=4)"
+
+  .TorqueStictionMax[4]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=4)"
+
+  .PowerStatusOffCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=4)"
+
+  .PowerStatusOffCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=4)"
+
+  .PowerStatusOffCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=4)"
+
+  .PowerStatusOffCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=4)"
+
+  .SpeedErrCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=4)"
+
+  .SpeedErrCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=4)"
+
+  .SpeedErrCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=4)"
+
+  .SpeedErrCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=4)"
+
+  .RwaCorrectCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "RwaCorrectCnt, cnt (SV_ID=4)"
+
+  .RwaVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "RwaVerifyCnt, cnt (SV_ID=4)"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=4)"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=4)"
+
+  .SpeedErrThr[1]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=4)"
+
+  .SpeedErrThr[2]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=4)"
+
+  .SpeedErrThr[3]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=4)"
+
+  .SpeedErrThr[4]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=4)"
+
+  .Inertia[1]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "Teldix RDR-12 Nominal Inertia Inertia, Nms^2 RWA1 (SV_ID=5)"
+
+  .Inertia[2]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA2 (SV_ID=5)"
+
+  .Inertia[3]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA3 (SV_ID=5)"
+
+  .Inertia[4]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA4 (SV_ID=5)"
+
+  .DcmRwaToBdy[1][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[1][2]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[1][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[1][4]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[2][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[2][2]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[2][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[2][4]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[3][1]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[3][2]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[3][3]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmRwaToBdy[3][4]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=5)"
+
+  .DcmBdyToRwa[1][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[1][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[1][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[2][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[2][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[2][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[3][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[3][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[3][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[4][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[4][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToRwa[4][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=5)"
+
+  .NullSpace[1]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=5)"
+
+  .NullSpace[2]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=5)"
+
+  .NullSpace[3]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=5)"
+
+  .NullSpace[4]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=5)"
+
+  .NumOfRwaTachCycles:
+    @datatype: uWord
+    @default: 6*NUM_AC_CYCLES
+    @description: "NumOfRwaTachCycles, cnt (SV_ID=5)"
+
+  .MaxTachCountValue:
+    @datatype: uWord
+    @default: 16383
+    @description: "MaxTachCountValue, 0x3FFF, cnt (SV_ID=5)"
+
+  .DeltaTachCountThr:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaTachCountThr, cnt (SV_ID=5)"
+
+  .Pad:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding for alignment (SV_ID=5)"
+
+  .Pulse2Angle:
+    @datatype: dReal
+    @default: TWO_PI / 24.0
+    @description: "Teldix Pulse2Angle, rad/pulse, 75119-801_C_Interface_Control_Document 4.4.5.3 (SV_ID=5)"
+
+  .Torque2VoltSF[1]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=5)"
+
+  .Torque2VoltSF[2]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=5)"
+
+  .Torque2VoltSF[3]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=5)"
+
+  .Torque2VoltSF[4]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=5)"
+
+  .Torque2VoltBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=5)"
+
+  .Torque2VoltBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=5)"
+
+  .Torque2VoltBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=5)"
+
+  .Torque2VoltBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=5)"
+
+  .CmdVolt2CntBias:
+    @datatype: dReal
+    @default: 0
+    @description: "CmdVolt2CntBias, cnt (SV_ID=5)"
+
+  .CmdVolt2CntSF:
+    @datatype: dReal
+    @default: 204.8
+    @description: "CmdVolt2CntSF, cnt/V (SV_ID=5)"
+
+  .TorqueSlewLmt[1]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=5)"
+
+  .TorqueSlewLmt[2]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=5)"
+
+  .TorqueSlewLmt[3]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=5)"
+
+  .TorqueSlewLmt[4]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=5)"
+
+  .TorqueCmdMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=5)"
+
+  .TorqueCmdMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=5)"
+
+  .TorqueCmdMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=5)"
+
+  .TorqueCmdMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=5)"
+
+  .TorqueScNullCtlMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=5)"
+
+  .TorqueScNullCtlMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=5)"
+
+  .TorqueScNullCtlMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=5)"
+
+  .TorqueScNullCtlMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=5)"
+
+  .BiasSpeedGain:
+    @datatype: dReal
+    @default: 1.6E-05
+    @description: "BiasSpeedGain, Nm/(rad/sec) (SV_ID=5)"
+
+  .BiasSpeedTorqueLmt:
+    @datatype: dReal
+    @default: 0.030
+    @description: "BiasSpeedTorqueLmt, Nm (SV_ID=5)"
+
+  .DefaultSpeedCmd[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=5)"
+
+  .DefaultSpeedCmd[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=5)"
+
+  .DefaultSpeedCmd[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=5)"
+
+  .DefaultSpeedCmd[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=5)"
+
+  .SpeedCmdMax:
+    @datatype: dReal
+    @default: 6000.0*RPM_2_RPS
+    @description: "Teldix SpeedCmdMax, rad/sec, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1 (SV_ID=5)"
+
+  .ViscousFrcSF[1]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "ViscousFrcSF, Nm/(rad/sec) RWA1 (SV_ID=5)"
+
+  .ViscousFrcSF[2]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA2 (SV_ID=5)"
+
+  .ViscousFrcSF[3]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA3 (SV_ID=5)"
+
+  .ViscousFrcSF[4]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA4 (SV_ID=5)"
+
+  .Kest[1]:
+    @datatype: dReal
+    @default: 2.10E-1
+    @description: "Teldix Kest (SV_ID=5)"
+
+  .Kest[2]:
+    @datatype: dReal
+    @default: 2.74E-4
+    @description: "Teldix Kest (SV_ID=5)"
+
+  .Kcnt[1]:
+    @datatype: dReal
+    @default: 0.071
+    @description: "Teldix Kcnt (SV_ID=5)"
+
+  .Kcnt[2]:
+    @datatype: dReal
+    @default: 1.00
+    @description: "Teldix Kcnt (SV_ID=5)"
+
+  .TorqueStictionMax[1]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=5)"
+
+  .TorqueStictionMax[2]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=5)"
+
+  .TorqueStictionMax[3]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=5)"
+
+  .TorqueStictionMax[4]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=5)"
+
+  .PowerStatusOffCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=5)"
+
+  .PowerStatusOffCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=5)"
+
+  .PowerStatusOffCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=5)"
+
+  .PowerStatusOffCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=5)"
+
+  .SpeedErrCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=5)"
+
+  .SpeedErrCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=5)"
+
+  .SpeedErrCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=5)"
+
+  .SpeedErrCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=5)"
+
+  .RwaCorrectCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "RwaCorrectCnt, cnt (SV_ID=5)"
+
+  .RwaVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "RwaVerifyCnt, cnt (SV_ID=5)"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=5)"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=5)"
+
+  .SpeedErrThr[1]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=5)"
+
+  .SpeedErrThr[2]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=5)"
+
+  .SpeedErrThr[3]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=5)"
+
+  .SpeedErrThr[4]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=5)"
+
+  .Inertia[1]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "Teldix RDR-12 Nominal Inertia Inertia, Nms^2 RWA1 (SV_ID=6)"
+
+  .Inertia[2]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA2 (SV_ID=6)"
+
+  .Inertia[3]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA3 (SV_ID=6)"
+
+  .Inertia[4]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA4 (SV_ID=6)"
+
+  .DcmRwaToBdy[1][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[1][2]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[1][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[1][4]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[2][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[2][2]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[2][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[2][4]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[3][1]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[3][2]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[3][3]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmRwaToBdy[3][4]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=6)"
+
+  .DcmBdyToRwa[1][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[1][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[1][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[2][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[2][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[2][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[3][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[3][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[3][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[4][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[4][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToRwa[4][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=6)"
+
+  .NullSpace[1]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=6)"
+
+  .NullSpace[2]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=6)"
+
+  .NullSpace[3]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=6)"
+
+  .NullSpace[4]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=6)"
+
+  .NumOfRwaTachCycles:
+    @datatype: uWord
+    @default: 6*NUM_AC_CYCLES
+    @description: "NumOfRwaTachCycles, cnt (SV_ID=6)"
+
+  .MaxTachCountValue:
+    @datatype: uWord
+    @default: 16383
+    @description: "MaxTachCountValue, 0x3FFF, cnt (SV_ID=6)"
+
+  .DeltaTachCountThr:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaTachCountThr, cnt (SV_ID=6)"
+
+  .Pad:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding for alignment (SV_ID=6)"
+
+  .Pulse2Angle:
+    @datatype: dReal
+    @default: TWO_PI / 24.0
+    @description: "Teldix Pulse2Angle, rad/pulse, 75119-801_C_Interface_Control_Document 4.4.5.3 (SV_ID=6)"
+
+  .Torque2VoltSF[1]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=6)"
+
+  .Torque2VoltSF[2]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=6)"
+
+  .Torque2VoltSF[3]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=6)"
+
+  .Torque2VoltSF[4]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=6)"
+
+  .Torque2VoltBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=6)"
+
+  .Torque2VoltBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=6)"
+
+  .Torque2VoltBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=6)"
+
+  .Torque2VoltBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=6)"
+
+  .CmdVolt2CntBias:
+    @datatype: dReal
+    @default: 0
+    @description: "CmdVolt2CntBias, cnt (SV_ID=6)"
+
+  .CmdVolt2CntSF:
+    @datatype: dReal
+    @default: 204.8
+    @description: "CmdVolt2CntSF, cnt/V (SV_ID=6)"
+
+  .TorqueSlewLmt[1]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=6)"
+
+  .TorqueSlewLmt[2]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=6)"
+
+  .TorqueSlewLmt[3]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=6)"
+
+  .TorqueSlewLmt[4]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=6)"
+
+  .TorqueCmdMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=6)"
+
+  .TorqueCmdMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=6)"
+
+  .TorqueCmdMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=6)"
+
+  .TorqueCmdMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=6)"
+
+  .TorqueScNullCtlMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=6)"
+
+  .TorqueScNullCtlMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=6)"
+
+  .TorqueScNullCtlMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=6)"
+
+  .TorqueScNullCtlMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=6)"
+
+  .BiasSpeedGain:
+    @datatype: dReal
+    @default: 1.6E-05
+    @description: "BiasSpeedGain, Nm/(rad/sec) (SV_ID=6)"
+
+  .BiasSpeedTorqueLmt:
+    @datatype: dReal
+    @default: 0.030
+    @description: "BiasSpeedTorqueLmt, Nm (SV_ID=6)"
+
+  .DefaultSpeedCmd[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=6)"
+
+  .DefaultSpeedCmd[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=6)"
+
+  .DefaultSpeedCmd[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=6)"
+
+  .DefaultSpeedCmd[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=6)"
+
+  .SpeedCmdMax:
+    @datatype: dReal
+    @default: 6000.0*RPM_2_RPS
+    @description: "Teldix SpeedCmdMax, rad/sec, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1 (SV_ID=6)"
+
+  .ViscousFrcSF[1]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "ViscousFrcSF, Nm/(rad/sec) RWA1 (SV_ID=6)"
+
+  .ViscousFrcSF[2]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA2 (SV_ID=6)"
+
+  .ViscousFrcSF[3]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA3 (SV_ID=6)"
+
+  .ViscousFrcSF[4]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA4 (SV_ID=6)"
+
+  .Kest[1]:
+    @datatype: dReal
+    @default: 2.10E-1
+    @description: "Teldix Kest (SV_ID=6)"
+
+  .Kest[2]:
+    @datatype: dReal
+    @default: 2.74E-4
+    @description: "Teldix Kest (SV_ID=6)"
+
+  .Kcnt[1]:
+    @datatype: dReal
+    @default: 0.071
+    @description: "Teldix Kcnt (SV_ID=6)"
+
+  .Kcnt[2]:
+    @datatype: dReal
+    @default: 1.00
+    @description: "Teldix Kcnt (SV_ID=6)"
+
+  .TorqueStictionMax[1]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=6)"
+
+  .TorqueStictionMax[2]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=6)"
+
+  .TorqueStictionMax[3]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=6)"
+
+  .TorqueStictionMax[4]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=6)"
+
+  .PowerStatusOffCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=6)"
+
+  .PowerStatusOffCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=6)"
+
+  .PowerStatusOffCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=6)"
+
+  .PowerStatusOffCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=6)"
+
+  .SpeedErrCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=6)"
+
+  .SpeedErrCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=6)"
+
+  .SpeedErrCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=6)"
+
+  .SpeedErrCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=6)"
+
+  .RwaCorrectCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "RwaCorrectCnt, cnt (SV_ID=6)"
+
+  .RwaVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "RwaVerifyCnt, cnt (SV_ID=6)"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=6)"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=6)"
+
+  .SpeedErrThr[1]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=6)"
+
+  .SpeedErrThr[2]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=6)"
+
+  .SpeedErrThr[3]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=6)"
+
+  .SpeedErrThr[4]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=6)"
+
+  .Inertia[1]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "Teldix RDR-12 Nominal Inertia Inertia, Nms^2 RWA1 (SV_ID=ELSE)"
+
+  .Inertia[2]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA2 (SV_ID=ELSE)"
+
+  .Inertia[3]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA3 (SV_ID=ELSE)"
+
+  .Inertia[4]:
+    @datatype: dReal
+    @default: 0.019099
+    @description: "RWA4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[1][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[1][2]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[1][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[1][4]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[2][1]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[2][2]:
+    @datatype: dReal
+    @default: -0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[2][3]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[2][4]:
+    @datatype: dReal
+    @default: 0.664463024388675
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[3][1]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[3][2]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[3][3]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmRwaToBdy[3][4]:
+    @datatype: dReal
+    @default: -0.342020143325669
+    @description: "DcmBdyToRwa, ND Ref: DN-SERAPHIM-GNC-111 Rev- Sect. 4 (SV_ID=ELSE)"
+
+  .DcmBdyToRwa[1][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[1][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[1][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[2][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[2][2]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[2][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[3][1]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[3][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[3][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[4][1]:
+    @datatype: dReal
+    @default: -0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[4][2]:
+    @datatype: dReal
+    @default: 0.376243659652856
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToRwa[4][3]:
+    @datatype: dReal
+    @default: -0.730951100040772
+    @description: "(SV_ID=ELSE)"
+
+  .NullSpace[1]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=ELSE)"
+
+  .NullSpace[2]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=ELSE)"
+
+  .NullSpace[3]:
+    @datatype: dReal
+    @default: -1
+    @description: "NullSpace, ND (SV_ID=ELSE)"
+
+  .NullSpace[4]:
+    @datatype: dReal
+    @default: 1
+    @description: "NullSpace, ND (SV_ID=ELSE)"
+
+  .NumOfRwaTachCycles:
+    @datatype: uWord
+    @default: 6*NUM_AC_CYCLES
+    @description: "NumOfRwaTachCycles, cnt (SV_ID=ELSE)"
+
+  .MaxTachCountValue:
+    @datatype: uWord
+    @default: 16383
+    @description: "MaxTachCountValue, 0x3FFF, cnt (SV_ID=ELSE)"
+
+  .DeltaTachCountThr:
+    @datatype: uWord
+    @default: 1
+    @description: "DeltaTachCountThr, cnt (SV_ID=ELSE)"
+
+  .Pad:
+    @datatype: uWord
+    @default: 0
+    @description: "Padding for alignment (SV_ID=ELSE)"
+
+  .Pulse2Angle:
+    @datatype: dReal
+    @default: TWO_PI / 24.0
+    @description: "Teldix Pulse2Angle, rad/pulse, 75119-801_C_Interface_Control_Document 4.4.5.3 (SV_ID=ELSE)"
+
+  .Torque2VoltSF[1]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=ELSE)"
+
+  .Torque2VoltSF[2]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=ELSE)"
+
+  .Torque2VoltSF[3]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=ELSE)"
+
+  .Torque2VoltSF[4]:
+    @datatype: dReal
+    @default: 133.333
+    @description: "Teldix Torque2VoltSF, V/Nm, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1.2 (SV_ID=ELSE)"
+
+  .Torque2VoltBias[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=ELSE)"
+
+  .Torque2VoltBias[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=ELSE)"
+
+  .Torque2VoltBias[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=ELSE)"
+
+  .Torque2VoltBias[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Torque2VoltBias, V (SV_ID=ELSE)"
+
+  .CmdVolt2CntBias:
+    @datatype: dReal
+    @default: 0
+    @description: "CmdVolt2CntBias, cnt (SV_ID=ELSE)"
+
+  .CmdVolt2CntSF:
+    @datatype: dReal
+    @default: 204.8
+    @description: "CmdVolt2CntSF, cnt/V (SV_ID=ELSE)"
+
+  .TorqueSlewLmt[1]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueSlewLmt[2]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueSlewLmt[3]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueSlewLmt[4]:
+    @datatype: dReal
+    @default: 0.0375
+    @description: "TorqueSlewLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueCmdMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueCmdMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueCmdMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueCmdMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.075
+    @description: "Teldix TorqueCmdMaxLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueScNullCtlMaxLmt[1]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueScNullCtlMaxLmt[2]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueScNullCtlMaxLmt[3]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=ELSE)"
+
+  .TorqueScNullCtlMaxLmt[4]:
+    @datatype: dReal
+    @default: 0.055
+    @description: "Teldix TorqueScNullCtlMaxLmt, Nm (SV_ID=ELSE)"
+
+  .BiasSpeedGain:
+    @datatype: dReal
+    @default: 1.6E-05
+    @description: "BiasSpeedGain, Nm/(rad/sec) (SV_ID=ELSE)"
+
+  .BiasSpeedTorqueLmt:
+    @datatype: dReal
+    @default: 0.030
+    @description: "BiasSpeedTorqueLmt, Nm (SV_ID=ELSE)"
+
+  .DefaultSpeedCmd[1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=ELSE)"
+
+  .DefaultSpeedCmd[2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=ELSE)"
+
+  .DefaultSpeedCmd[3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=ELSE)"
+
+  .DefaultSpeedCmd[4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "DefaultSpeedCmd, rad/sec (SV_ID=ELSE)"
+
+  .SpeedCmdMax:
+    @datatype: dReal
+    @default: 6000.0*RPM_2_RPS
+    @description: "Teldix SpeedCmdMax, rad/sec, RWA Spec 6554-PF4640 Rev B Sect. 3.2.1.1 (SV_ID=ELSE)"
+
+  .ViscousFrcSF[1]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "ViscousFrcSF, Nm/(rad/sec) RWA1 (SV_ID=ELSE)"
+
+  .ViscousFrcSF[2]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA2 (SV_ID=ELSE)"
+
+  .ViscousFrcSF[3]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA3 (SV_ID=ELSE)"
+
+  .ViscousFrcSF[4]:
+    @datatype: dReal
+    @default: 1.671e-5
+    @description: "RWA4 (SV_ID=ELSE)"
+
+  .Kest[1]:
+    @datatype: dReal
+    @default: 2.10E-1
+    @description: "Teldix Kest (SV_ID=ELSE)"
+
+  .Kest[2]:
+    @datatype: dReal
+    @default: 2.74E-4
+    @description: "Teldix Kest (SV_ID=ELSE)"
+
+  .Kcnt[1]:
+    @datatype: dReal
+    @default: 0.071
+    @description: "Teldix Kcnt (SV_ID=ELSE)"
+
+  .Kcnt[2]:
+    @datatype: dReal
+    @default: 1.00
+    @description: "Teldix Kcnt (SV_ID=ELSE)"
+
+  .TorqueStictionMax[1]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=ELSE)"
+
+  .TorqueStictionMax[2]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=ELSE)"
+
+  .TorqueStictionMax[3]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=ELSE)"
+
+  .TorqueStictionMax[4]:
+    @datatype: dReal
+    @default: 0.020
+    @description: "Teldix TorqueStictionMax, Nm (SV_ID=ELSE)"
+
+  .PowerStatusOffCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=ELSE)"
+
+  .PowerStatusOffCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=ELSE)"
+
+  .PowerStatusOffCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=ELSE)"
+
+  .PowerStatusOffCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "Fdc PowerStatusOffCnt, cnt (SV_ID=ELSE)"
+
+  .SpeedErrCnt[1]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=ELSE)"
+
+  .SpeedErrCnt[2]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=ELSE)"
+
+  .SpeedErrCnt[3]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=ELSE)"
+
+  .SpeedErrCnt[4]:
+    @datatype: uWord
+    @default: 10*NUM_AC_CYCLES
+    @description: "SpeedErrCnt, cnt (SV_ID=ELSE)"
+
+  .RwaCorrectCnt:
+    @datatype: uWord
+    @default: 60*NUM_AC_CYCLES
+    @description: "RwaCorrectCnt, cnt (SV_ID=ELSE)"
+
+  .RwaVerifyCnt:
+    @datatype: uWord
+    @default: 120*NUM_AC_CYCLES
+    @description: "RwaVerifyCnt, cnt (SV_ID=ELSE)"
+
+  .Spare[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=ELSE)"
+
+  .Spare[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=ELSE)"
+
+  .SpeedErrThr[1]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=ELSE)"
+
+  .SpeedErrThr[2]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=ELSE)"
+
+  .SpeedErrThr[3]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=ELSE)"
+
+  .SpeedErrThr[4]:
+    @datatype: dReal
+    @default: 105.0*RPM_2_RPS
+    @description: "SpeedErrThr, rad/sec (SV_ID=ELSE)"
+
+}
+
+table ac_sad_table_type {
+  @buildstruct!
+  .DcmBdyToSad[1]:
+    @datatype: uMatrix
+    @default: { { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=1)"
+
+  .DcmBdyToSad[2]:
+    @datatype: uMatrix
+    @default: { { { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=1)"
+
+  .SadRotDir[1]:
+    @datatype: dReal
+    @default: 1
+    @description: "SadRotDir Ref: SADA FM Calibration Report SERAPHIM-RSZ-RP-0027 rev. 1.0, SADE FM03 Cal. Params Table 6.1.3 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=1)"
+
+  .SadRotDir[2]:
+    @datatype: dReal
+    @default: -1
+    @description: "SadRotDir Ref: SADA FM Calibration Report SERAPHIM-RSZ-RP-0027 rev. 1.0, SADE FM03 Cal. Params Table 6.1.3 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=1)"
+
+  .PotOffset[1][1]:
+    @datatype: uWord
+    @default: 28738
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=1)"
+
+  .PotOffset[1][2]:
+    @datatype: uWord
+    @default: 57526
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=1)"
+
+  .PotOffset[2][1]:
+    @datatype: uWord
+    @default: 28670
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=1)"
+
+  .PotOffset[2][2]:
+    @datatype: uWord
+    @default: 57487
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=1)"
+
+  .ElecTravel[1][1]:
+    @datatype: uWord
+    @default: 57226
+    @description: "SAD2 (SV_ID=1)"
+
+  .ElecTravel[1][2]:
+    @datatype: uWord
+    @default: 57247
+    @description: "SAD2 (SV_ID=1)"
+
+  .ElecTravel[2][1]:
+    @datatype: uWord
+    @default: 57251
+    @description: "SAD2 (SV_ID=1)"
+
+  .ElecTravel[2][2]:
+    @datatype: uWord
+    @default: 57242
+    @description: "SAD2 (SV_ID=1)"
+
+  .MaxPotValue[1]:
+    @datatype: uWord
+    @default: 3300
+    @description: "MaxPotValue[SadID] (SV_ID=1)"
+
+  .MaxPotValue[2]:
+    @datatype: uWord
+    @default: 3283
+    @description: "MaxPotValue[SadID] (SV_ID=1)"
+
+  .MinPotValue[1]:
+    @datatype: uWord
+    @default: 2
+    @description: "MinPotValue[SadID] (SV_ID=1)"
+
+  .MinPotValue[2]:
+    @datatype: uWord
+    @default: 2
+    @description: "MinPotValue[SadID] (SV_ID=1)"
+
+  .RadToStepScaleFactor:
+    @datatype: dReal
+    @default: 1 / 0.00625 / DEG_2_RAD
+    @description: "RadToStepScaleFactor, Conversion factor from rad to SAD steps, step/rad Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 08/28/2019, Secion 6.2 (SV_ID=1)"
+
+  .PotFilterA1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterA1 (SV_ID=1)"
+
+  .PotFilterB1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterB1 Ref: Seraphim SADA DD, SERAPHIM-RSZ-DD-0001 Issue 1.0 10.01.2019, Secion 5.3.3.5 MAINPOT, REDPOT PotDeadbandSize[SadID][PotID], Nominally step once every 10 cycles (1Hz), rad (SV_ID=1)"
+
+  .PotDeadbandSize[1][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=1)"
+
+  .PotDeadbandSize[1][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=1)"
+
+  .PotDeadbandSize[2][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=1)"
+
+  .PotDeadbandSize[2][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=1)"
+
+  .PotDeadbandMargin[1][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=1)"
+
+  .PotDeadbandMargin[1][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=1)"
+
+  .PotDeadbandMargin[2][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=1)"
+
+  .PotDeadbandMargin[2][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=1)"
+
+  .AngleCtrlDeadband:
+    @datatype: dReal
+    @default: 0.00417 * 10 * DEG_2_RAD
+    @description: "AngleCtrlDeadband, Nominally step once every 10 cycles (1Hz), rad (SV_ID=1)"
+
+  .MedModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.00417 * DEG_2_RAD
+    @description: "MedModeLoThr, Error low threshold to use Medium Motor Mode, rad ( sized to fall behind up to two Low Mode 1Hz cycle's rotation beyond the deadband ) (SV_ID=1)"
+
+  .HighModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.2 * DEG_2_RAD
+    @description: "HighModeLoThr, Error low threshold to use High Motor Mode, rad ( max rotation of Medium Mode in 2 1Hz cycles ) (SV_ID=1)"
+
+  .MaxSteps[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MaxSteps, Maximum number of steps per control cycle, [HOLD_MODE, LOW_MODE, MED_MODE, HIGH_MODE] (SV_ID=1)"
+
+  .MaxSteps[2]:
+    @datatype: uWord
+    @default: (uWord) (0.00417/0.00625*77/80)
+    @description: "( sized as rotation rate [deg/sec] / deg per step * 77 / 80 minor frames) (SV_ID=1)"
+
+  .MaxSteps[3]:
+    @datatype: uWord
+    @default: (uWord) (0.2/0.00625*77/80)
+    @description: "Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.8.4.1.1 (SV_ID=1)"
+
+  .MaxSteps[4]:
+    @datatype: uWord
+    @default: (uWord) (1.0/0.00625*77/80)
+    @description: "(SV_ID=1)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0x0400
+    @description: "CycleMask, SAD Command Cycle Mask, Cycle 10 (minor frame 77) (SV_ID=1)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, SAD Frame Mask, Every Frame 1 Hz (SV_ID=1)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=1)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3
+    @description: "SADE power off counter initial value, SAD Cycles (SV_ID=1)"
+
+  .WarmupTime:
+    @datatype: dReal
+    @default: 25
+    @description: "WarmupTime, Duration for SADE warmup period, SADE cycles Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.5.1 UseHighInAcsMode, Flag to allow High Motor Mode for each ACS Mode (SV_ID=1)"
+
+  .UseHighInAcsMode[1]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Standby (SV_ID=1)"
+
+  .UseHighInAcsMode[2]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "RateNulling (SV_ID=1)"
+
+  .UseHighInAcsMode[3]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunAcquisition (SV_ID=1)"
+
+  .UseHighInAcsMode[4]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunPointing (SV_ID=1)"
+
+  .UseHighInAcsMode[5]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "DeltaV (SV_ID=1)"
+
+  .UseHighInAcsMode[6]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Normal (SV_ID=1)"
+
+  .UseHighInAcsMode[7]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Target Pointing (SV_ID=1)"
+
+  .UseHighInAcsMode[8]:
+    @datatype: uByte
+    @default: FALSE
+    @description: "Mission (SV_ID=1)"
+
+  .AngleErrorThreshold:
+    @datatype: dReal
+    @default: 20.0 * DEG_2_RAD
+    @description: "Fdc AngleErrorThreshold, Maximum angle error between commanded and measured angle, radians (SV_ID=1)"
+
+  .SunAngleErrorThreshold:
+    @datatype: dReal
+    @default: 25.0 * DEG_2_RAD
+    @description: "SunAngleErrorThreshold, Maximum angle error between SA and sun, radians (SV_ID=1)"
+
+  .PotAngleErrorCnt:
+    @datatype: uWord
+    @default: 60
+    @description: "PotAngleErrorCnt, Pot Angle Error counter initial value, SAD Cycles (SV_ID=1)"
+
+  .SunAngleErrorCnt:
+    @datatype: uWord
+    @default: 15*60
+    @description: "SunAngleErrCnt, Sun Angle Error counter initial value, SAD Cycles (SV_ID=1)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 20
+    @description: "PowerStatusOffCnt, SADE Power Status Off counter initial value, SAD Cycles (SV_ID=1)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=1)"
+
+  .DcmBdyToSad[1]:
+    @datatype: uMatrix
+    @default: { { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=2)"
+
+  .DcmBdyToSad[2]:
+    @datatype: uMatrix
+    @default: { { { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=2)"
+
+  .SadRotDir[1]:
+    @datatype: dReal
+    @default: 1
+    @description: "SadRotDir Ref: SADA PFM Calibration Report SERAPHIM-RSZ-RP-0033 rev. 1.0, SADE FM02 Cal. Params Table 6.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=2)"
+
+  .SadRotDir[2]:
+    @datatype: dReal
+    @default: -1
+    @description: "SadRotDir Ref: SADA PFM Calibration Report SERAPHIM-RSZ-RP-0033 rev. 1.0, SADE FM02 Cal. Params Table 6.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=2)"
+
+  .PotOffset[1][1]:
+    @datatype: uWord
+    @default: 28835
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=2)"
+
+  .PotOffset[1][2]:
+    @datatype: uWord
+    @default: 57595
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=2)"
+
+  .PotOffset[2][1]:
+    @datatype: uWord
+    @default: 28844
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=2)"
+
+  .PotOffset[2][2]:
+    @datatype: uWord
+    @default: 39
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=2)"
+
+  .ElecTravel[1][1]:
+    @datatype: uWord
+    @default: 57255
+    @description: "SAD2 (SV_ID=2)"
+
+  .ElecTravel[1][2]:
+    @datatype: uWord
+    @default: 57230
+    @description: "SAD2 (SV_ID=2)"
+
+  .ElecTravel[2][1]:
+    @datatype: uWord
+    @default: 57297
+    @description: "SAD2 (SV_ID=2)"
+
+  .ElecTravel[2][2]:
+    @datatype: uWord
+    @default: 57259
+    @description: "SAD2 (SV_ID=2)"
+
+  .MaxPotValue[1]:
+    @datatype: uWord
+    @default: 3282
+    @description: "MaxPotValue[SadID] (SV_ID=2)"
+
+  .MaxPotValue[2]:
+    @datatype: uWord
+    @default: 3282
+    @description: "MaxPotValue[SadID] (SV_ID=2)"
+
+  .MinPotValue[1]:
+    @datatype: uWord
+    @default: 1
+    @description: "MinPotValue[SadID] (SV_ID=2)"
+
+  .MinPotValue[2]:
+    @datatype: uWord
+    @default: 1
+    @description: "MinPotValue[SadID] (SV_ID=2)"
+
+  .RadToStepScaleFactor:
+    @datatype: dReal
+    @default: 1 / 0.00625 / DEG_2_RAD
+    @description: "RadToStepScaleFactor, Conversion factor from rad to SAD steps, step/rad Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 08/28/2019, Secion 6.2 (SV_ID=2)"
+
+  .PotFilterA1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterA1 (SV_ID=2)"
+
+  .PotFilterB1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterB1 Ref: Seraphim SADA DD, SERAPHIM-RSZ-DD-0001 Issue 1.0 10.01.2019, Secion 5.3.3.5 MAINPOT, REDPOT PotDeadbandSize[SadID][PotID], Nominally step once every 10 cycles (1Hz), rad (SV_ID=2)"
+
+  .PotDeadbandSize[1][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=2)"
+
+  .PotDeadbandSize[1][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=2)"
+
+  .PotDeadbandSize[2][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=2)"
+
+  .PotDeadbandSize[2][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=2)"
+
+  .PotDeadbandMargin[1][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=2)"
+
+  .PotDeadbandMargin[1][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=2)"
+
+  .PotDeadbandMargin[2][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=2)"
+
+  .PotDeadbandMargin[2][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=2)"
+
+  .AngleCtrlDeadband:
+    @datatype: dReal
+    @default: 0.00417 * 10 * DEG_2_RAD
+    @description: "AngleCtrlDeadband, Nominally step once every 10 cycles (1Hz), rad (SV_ID=2)"
+
+  .MedModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.00417 * DEG_2_RAD
+    @description: "MedModeLoThr, Error low threshold to use Medium Motor Mode, rad ( sized to fall behind up to two Low Mode 1Hz cycle's rotation beyond the deadband ) (SV_ID=2)"
+
+  .HighModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.2 * DEG_2_RAD
+    @description: "HighModeLoThr, Error low threshold to use High Motor Mode, rad ( max rotation of Medium Mode in 2 1Hz cycles ) (SV_ID=2)"
+
+  .MaxSteps[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MaxSteps, Maximum number of steps per control cycle, [HOLD_MODE, LOW_MODE, MED_MODE, HIGH_MODE] (SV_ID=2)"
+
+  .MaxSteps[2]:
+    @datatype: uWord
+    @default: (uWord) (0.00417/0.00625*77/80)
+    @description: "( sized as rotation rate [deg/sec] / deg per step * 77 / 80 minor frames) (SV_ID=2)"
+
+  .MaxSteps[3]:
+    @datatype: uWord
+    @default: (uWord) (0.2/0.00625*77/80)
+    @description: "Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.8.4.1.1 (SV_ID=2)"
+
+  .MaxSteps[4]:
+    @datatype: uWord
+    @default: (uWord) (1.0/0.00625*77/80)
+    @description: "(SV_ID=2)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0x0400
+    @description: "CycleMask, SAD Command Cycle Mask, Cycle 10 (minor frame 77) (SV_ID=2)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, SAD Frame Mask, Every Frame 1 Hz (SV_ID=2)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=2)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3
+    @description: "SADE power off counter initial value, SAD Cycles (SV_ID=2)"
+
+  .WarmupTime:
+    @datatype: dReal
+    @default: 25
+    @description: "WarmupTime, Duration for SADE warmup period, SADE cycles Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.5.1 UseHighInAcsMode, Flag to allow High Motor Mode for each ACS Mode (SV_ID=2)"
+
+  .UseHighInAcsMode[1]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Standby (SV_ID=2)"
+
+  .UseHighInAcsMode[2]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "RateNulling (SV_ID=2)"
+
+  .UseHighInAcsMode[3]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunAcquisition (SV_ID=2)"
+
+  .UseHighInAcsMode[4]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunPointing (SV_ID=2)"
+
+  .UseHighInAcsMode[5]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "DeltaV (SV_ID=2)"
+
+  .UseHighInAcsMode[6]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Normal (SV_ID=2)"
+
+  .UseHighInAcsMode[7]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Target Pointing (SV_ID=2)"
+
+  .UseHighInAcsMode[8]:
+    @datatype: uByte
+    @default: FALSE
+    @description: "Mission (SV_ID=2)"
+
+  .AngleErrorThreshold:
+    @datatype: dReal
+    @default: 20.0 * DEG_2_RAD
+    @description: "Fdc AngleErrorThreshold, Maximum angle error between commanded and measured angle, radians (SV_ID=2)"
+
+  .SunAngleErrorThreshold:
+    @datatype: dReal
+    @default: 25.0 * DEG_2_RAD
+    @description: "SunAngleErrorThreshold, Maximum angle error between SA and sun, radians (SV_ID=2)"
+
+  .PotAngleErrorCnt:
+    @datatype: uWord
+    @default: 60
+    @description: "PotAngleErrorCnt, Pot Angle Error counter initial value, SAD Cycles (SV_ID=2)"
+
+  .SunAngleErrorCnt:
+    @datatype: uWord
+    @default: 15*60
+    @description: "SunAngleErrCnt, Sun Angle Error counter initial value, SAD Cycles (SV_ID=2)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 20
+    @description: "PowerStatusOffCnt, SADE Power Status Off counter initial value, SAD Cycles (SV_ID=2)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=2)"
+
+  .DcmBdyToSad[1]:
+    @datatype: uMatrix
+    @default: { { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=3)"
+
+  .DcmBdyToSad[2]:
+    @datatype: uMatrix
+    @default: { { { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=3)"
+
+  .SadRotDir[1]:
+    @datatype: dReal
+    @default: 1
+    @description: "SadRotDir Ref: SADA FM Calibration Report SERAPHIM-RSZ-RP-0027 rev. 1.0, SADE FM04 Cal. Params Table 6.1.4 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=3)"
+
+  .SadRotDir[2]:
+    @datatype: dReal
+    @default: -1
+    @description: "SadRotDir Ref: SADA FM Calibration Report SERAPHIM-RSZ-RP-0027 rev. 1.0, SADE FM04 Cal. Params Table 6.1.4 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=3)"
+
+  .PotOffset[1][1]:
+    @datatype: uWord
+    @default: 28706
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=3)"
+
+  .PotOffset[1][2]:
+    @datatype: uWord
+    @default: 57515
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=3)"
+
+  .PotOffset[2][1]:
+    @datatype: uWord
+    @default: 28741
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=3)"
+
+  .PotOffset[2][2]:
+    @datatype: uWord
+    @default: 57584
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=3)"
+
+  .ElecTravel[1][1]:
+    @datatype: uWord
+    @default: 57183
+    @description: "SAD2 (SV_ID=3)"
+
+  .ElecTravel[1][2]:
+    @datatype: uWord
+    @default: 57270
+    @description: "SAD2 (SV_ID=3)"
+
+  .ElecTravel[2][1]:
+    @datatype: uWord
+    @default: 57244
+    @description: "SAD2 (SV_ID=3)"
+
+  .ElecTravel[2][2]:
+    @datatype: uWord
+    @default: 57208
+    @description: "SAD2 (SV_ID=3)"
+
+  .MaxPotValue[1]:
+    @datatype: uWord
+    @default: 3300
+    @description: "MaxPotValue[SadID] (SV_ID=3)"
+
+  .MaxPotValue[2]:
+    @datatype: uWord
+    @default: 3282
+    @description: "MaxPotValue[SadID] (SV_ID=3)"
+
+  .MinPotValue[1]:
+    @datatype: uWord
+    @default: 2
+    @description: "MinPotValue[SadID] (SV_ID=3)"
+
+  .MinPotValue[2]:
+    @datatype: uWord
+    @default: 2
+    @description: "MinPotValue[SadID] (SV_ID=3)"
+
+  .RadToStepScaleFactor:
+    @datatype: dReal
+    @default: 1 / 0.00625 / DEG_2_RAD
+    @description: "RadToStepScaleFactor, Conversion factor from rad to SAD steps, step/rad Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 08/28/2019, Secion 6.2 (SV_ID=3)"
+
+  .PotFilterA1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterA1 (SV_ID=3)"
+
+  .PotFilterB1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterB1 Ref: Seraphim SADA DD, SERAPHIM-RSZ-DD-0001 Issue 1.0 10.01.2019, Secion 5.3.3.5 MAINPOT, REDPOT PotDeadbandSize[SadID][PotID], Nominally step once every 10 cycles (1Hz), rad (SV_ID=3)"
+
+  .PotDeadbandSize[1][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=3)"
+
+  .PotDeadbandSize[1][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=3)"
+
+  .PotDeadbandSize[2][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=3)"
+
+  .PotDeadbandSize[2][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=3)"
+
+  .PotDeadbandMargin[1][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=3)"
+
+  .PotDeadbandMargin[1][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=3)"
+
+  .PotDeadbandMargin[2][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=3)"
+
+  .PotDeadbandMargin[2][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=3)"
+
+  .AngleCtrlDeadband:
+    @datatype: dReal
+    @default: 0.00417 * 10 * DEG_2_RAD
+    @description: "AngleCtrlDeadband, Nominally step once every 10 cycles (1Hz), rad (SV_ID=3)"
+
+  .MedModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.00417 * DEG_2_RAD
+    @description: "MedModeLoThr, Error low threshold to use Medium Motor Mode, rad ( sized to fall behind up to two Low Mode 1Hz cycle's rotation beyond the deadband ) (SV_ID=3)"
+
+  .HighModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.2 * DEG_2_RAD
+    @description: "HighModeLoThr, Error low threshold to use High Motor Mode, rad ( max rotation of Medium Mode in 2 1Hz cycles ) (SV_ID=3)"
+
+  .MaxSteps[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MaxSteps, Maximum number of steps per control cycle, [HOLD_MODE, LOW_MODE, MED_MODE, HIGH_MODE] (SV_ID=3)"
+
+  .MaxSteps[2]:
+    @datatype: uWord
+    @default: (uWord) (0.00417/0.00625*77/80)
+    @description: "( sized as rotation rate [deg/sec] / deg per step * 77 / 80 minor frames) (SV_ID=3)"
+
+  .MaxSteps[3]:
+    @datatype: uWord
+    @default: (uWord) (0.2/0.00625*77/80)
+    @description: "Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.8.4.1.1 (SV_ID=3)"
+
+  .MaxSteps[4]:
+    @datatype: uWord
+    @default: (uWord) (1.0/0.00625*77/80)
+    @description: "(SV_ID=3)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0x0400
+    @description: "CycleMask, SAD Command Cycle Mask, Cycle 10 (minor frame 77) (SV_ID=3)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, SAD Frame Mask, Every Frame 1 Hz (SV_ID=3)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=3)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3
+    @description: "SADE power off counter initial value, SAD Cycles (SV_ID=3)"
+
+  .WarmupTime:
+    @datatype: dReal
+    @default: 25
+    @description: "WarmupTime, Duration for SADE warmup period, SADE cycles Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.5.1 UseHighInAcsMode, Flag to allow High Motor Mode for each ACS Mode (SV_ID=3)"
+
+  .UseHighInAcsMode[1]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Standby (SV_ID=3)"
+
+  .UseHighInAcsMode[2]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "RateNulling (SV_ID=3)"
+
+  .UseHighInAcsMode[3]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunAcquisition (SV_ID=3)"
+
+  .UseHighInAcsMode[4]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunPointing (SV_ID=3)"
+
+  .UseHighInAcsMode[5]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "DeltaV (SV_ID=3)"
+
+  .UseHighInAcsMode[6]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Normal (SV_ID=3)"
+
+  .UseHighInAcsMode[7]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Target Pointing (SV_ID=3)"
+
+  .UseHighInAcsMode[8]:
+    @datatype: uByte
+    @default: FALSE
+    @description: "Mission (SV_ID=3)"
+
+  .AngleErrorThreshold:
+    @datatype: dReal
+    @default: 20.0 * DEG_2_RAD
+    @description: "Fdc AngleErrorThreshold, Maximum angle error between commanded and measured angle, radians (SV_ID=3)"
+
+  .SunAngleErrorThreshold:
+    @datatype: dReal
+    @default: 25.0 * DEG_2_RAD
+    @description: "SunAngleErrorThreshold, Maximum angle error between SA and sun, radians (SV_ID=3)"
+
+  .PotAngleErrorCnt:
+    @datatype: uWord
+    @default: 60
+    @description: "PotAngleErrorCnt, Pot Angle Error counter initial value, SAD Cycles (SV_ID=3)"
+
+  .SunAngleErrorCnt:
+    @datatype: uWord
+    @default: 15*60
+    @description: "SunAngleErrCnt, Sun Angle Error counter initial value, SAD Cycles (SV_ID=3)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 20
+    @description: "PowerStatusOffCnt, SADE Power Status Off counter initial value, SAD Cycles (SV_ID=3)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=3)"
+
+  .DcmBdyToSad[1]:
+    @datatype: uMatrix
+    @default: { { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=4)"
+
+  .DcmBdyToSad[2]:
+    @datatype: uMatrix
+    @default: { { { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=4)"
+
+  .SadRotDir[1]:
+    @datatype: dReal
+    @default: 1
+    @description: "SadRotDir Ref: SADA FM Calibration Report FOXHOUND-RSS-RP-0021 rev. 1.0, SADE FM04 Cal. Params Table 7.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=4)"
+
+  .SadRotDir[2]:
+    @datatype: dReal
+    @default: -1
+    @description: "SadRotDir Ref: SADA FM Calibration Report FOXHOUND-RSS-RP-0021 rev. 1.0, SADE FM04 Cal. Params Table 7.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=4)"
+
+  .PotOffset[1][1]:
+    @datatype: uWord
+    @default: 28669
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=4)"
+
+  .PotOffset[1][2]:
+    @datatype: uWord
+    @default: 57454
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=4)"
+
+  .PotOffset[2][1]:
+    @datatype: uWord
+    @default: 28694
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=4)"
+
+  .PotOffset[2][2]:
+    @datatype: uWord
+    @default: 57482
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=4)"
+
+  .ElecTravel[1][1]:
+    @datatype: uWord
+    @default: 57189
+    @description: "SAD2 (SV_ID=4)"
+
+  .ElecTravel[1][2]:
+    @datatype: uWord
+    @default: 57197
+    @description: "SAD2 (SV_ID=4)"
+
+  .ElecTravel[2][1]:
+    @datatype: uWord
+    @default: 57224
+    @description: "SAD2 (SV_ID=4)"
+
+  .ElecTravel[2][2]:
+    @datatype: uWord
+    @default: 57190
+    @description: "SAD2 (SV_ID=4)"
+
+  .MaxPotValue[1]:
+    @datatype: uWord
+    @default: 3106
+    @description: "MaxPotValue[SadID] (SV_ID=4)"
+
+  .MaxPotValue[2]:
+    @datatype: uWord
+    @default: 3092
+    @description: "MaxPotValue[SadID] (SV_ID=4)"
+
+  .MinPotValue[1]:
+    @datatype: uWord
+    @default: 3
+    @description: "MinPotValue[SadID] (SV_ID=4)"
+
+  .MinPotValue[2]:
+    @datatype: uWord
+    @default: 2
+    @description: "MinPotValue[SadID] (SV_ID=4)"
+
+  .RadToStepScaleFactor:
+    @datatype: dReal
+    @default: 1 / 0.00625 / DEG_2_RAD
+    @description: "RadToStepScaleFactor, Conversion factor from rad to SAD steps, step/rad Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 08/28/2019, Secion 6.2 (SV_ID=4)"
+
+  .PotFilterA1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterA1 (SV_ID=4)"
+
+  .PotFilterB1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterB1 Ref: Seraphim SADA DD, SERAPHIM-RSZ-DD-0001 Issue 1.0 10.01.2019, Secion 5.3.3.5 MAINPOT, REDPOT PotDeadbandSize[SadID][PotID], Nominally step once every 10 cycles (1Hz), rad (SV_ID=4)"
+
+  .PotDeadbandSize[1][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=4)"
+
+  .PotDeadbandSize[1][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=4)"
+
+  .PotDeadbandSize[2][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=4)"
+
+  .PotDeadbandSize[2][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=4)"
+
+  .PotDeadbandMargin[1][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=4)"
+
+  .PotDeadbandMargin[1][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=4)"
+
+  .PotDeadbandMargin[2][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=4)"
+
+  .PotDeadbandMargin[2][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=4)"
+
+  .AngleCtrlDeadband:
+    @datatype: dReal
+    @default: 0.00417 * 10 * DEG_2_RAD
+    @description: "AngleCtrlDeadband, Nominally step once every 10 cycles (1Hz), rad (SV_ID=4)"
+
+  .MedModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.00417 * DEG_2_RAD
+    @description: "MedModeLoThr, Error low threshold to use Medium Motor Mode, rad ( sized to fall behind up to two Low Mode 1Hz cycle's rotation beyond the deadband ) (SV_ID=4)"
+
+  .HighModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.2 * DEG_2_RAD
+    @description: "HighModeLoThr, Error low threshold to use High Motor Mode, rad ( max rotation of Medium Mode in 2 1Hz cycles ) (SV_ID=4)"
+
+  .MaxSteps[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MaxSteps, Maximum number of steps per control cycle, [HOLD_MODE, LOW_MODE, MED_MODE, HIGH_MODE] (SV_ID=4)"
+
+  .MaxSteps[2]:
+    @datatype: uWord
+    @default: (uWord) (0.00417/0.00625*77/80)
+    @description: "( sized as rotation rate [deg/sec] / deg per step * 77 / 80 minor frames) (SV_ID=4)"
+
+  .MaxSteps[3]:
+    @datatype: uWord
+    @default: (uWord) (0.2/0.00625*77/80)
+    @description: "Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.8.4.1.1 (SV_ID=4)"
+
+  .MaxSteps[4]:
+    @datatype: uWord
+    @default: (uWord) (1.0/0.00625*77/80)
+    @description: "(SV_ID=4)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0x0400
+    @description: "CycleMask, SAD Command Cycle Mask, Cycle 10 (minor frame 77) (SV_ID=4)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, SAD Frame Mask, Every Frame 1 Hz (SV_ID=4)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=4)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3
+    @description: "SADE power off counter initial value, SAD Cycles (SV_ID=4)"
+
+  .WarmupTime:
+    @datatype: dReal
+    @default: 25
+    @description: "WarmupTime, Duration for SADE warmup period, SADE cycles Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.5.1 UseHighInAcsMode, Flag to allow High Motor Mode for each ACS Mode (SV_ID=4)"
+
+  .UseHighInAcsMode[1]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Standby (SV_ID=4)"
+
+  .UseHighInAcsMode[2]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "RateNulling (SV_ID=4)"
+
+  .UseHighInAcsMode[3]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunAcquisition (SV_ID=4)"
+
+  .UseHighInAcsMode[4]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunPointing (SV_ID=4)"
+
+  .UseHighInAcsMode[5]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "DeltaV (SV_ID=4)"
+
+  .UseHighInAcsMode[6]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Normal (SV_ID=4)"
+
+  .UseHighInAcsMode[7]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Target Pointing (SV_ID=4)"
+
+  .UseHighInAcsMode[8]:
+    @datatype: uByte
+    @default: FALSE
+    @description: "Mission (SV_ID=4)"
+
+  .AngleErrorThreshold:
+    @datatype: dReal
+    @default: 20.0 * DEG_2_RAD
+    @description: "Fdc AngleErrorThreshold, Maximum angle error between commanded and measured angle, radians (SV_ID=4)"
+
+  .SunAngleErrorThreshold:
+    @datatype: dReal
+    @default: 25.0 * DEG_2_RAD
+    @description: "SunAngleErrorThreshold, Maximum angle error between SA and sun, radians (SV_ID=4)"
+
+  .PotAngleErrorCnt:
+    @datatype: uWord
+    @default: 60
+    @description: "PotAngleErrorCnt, Pot Angle Error counter initial value, SAD Cycles (SV_ID=4)"
+
+  .SunAngleErrorCnt:
+    @datatype: uWord
+    @default: 15*60
+    @description: "SunAngleErrCnt, Sun Angle Error counter initial value, SAD Cycles (SV_ID=4)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 20
+    @description: "PowerStatusOffCnt, SADE Power Status Off counter initial value, SAD Cycles (SV_ID=4)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=4)"
+
+  .DcmBdyToSad[1]:
+    @datatype: uMatrix
+    @default: { { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=5)"
+
+  .DcmBdyToSad[2]:
+    @datatype: uMatrix
+    @default: { { { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=5)"
+
+  .SadRotDir[1]:
+    @datatype: dReal
+    @default: 1
+    @description: "SadRotDir Ref: SADA FM Calibration Report FOXHOUND-RSS-RP-0028 rev. 1.0, SADE FM006 Cal. Params Table 7.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=5)"
+
+  .SadRotDir[2]:
+    @datatype: dReal
+    @default: -1
+    @description: "SadRotDir Ref: SADA FM Calibration Report FOXHOUND-RSS-RP-0028 rev. 1.0, SADE FM006 Cal. Params Table 7.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=5)"
+
+  .PotOffset[1][1]:
+    @datatype: uWord
+    @default: 28690
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=5)"
+
+  .PotOffset[1][2]:
+    @datatype: uWord
+    @default: 57456
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=5)"
+
+  .PotOffset[2][1]:
+    @datatype: uWord
+    @default: 28723
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=5)"
+
+  .PotOffset[2][2]:
+    @datatype: uWord
+    @default: 57547
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=5)"
+
+  .ElecTravel[1][1]:
+    @datatype: uWord
+    @default: 57244
+    @description: "SAD2 (SV_ID=5)"
+
+  .ElecTravel[1][2]:
+    @datatype: uWord
+    @default: 57220
+    @description: "SAD2 (SV_ID=5)"
+
+  .ElecTravel[2][1]:
+    @datatype: uWord
+    @default: 57162
+    @description: "SAD2 (SV_ID=5)"
+
+  .ElecTravel[2][2]:
+    @datatype: uWord
+    @default: 57168
+    @description: "SAD2 (SV_ID=5)"
+
+  .MaxPotValue[1]:
+    @datatype: uWord
+    @default: 3084
+    @description: "MaxPotValue[SadID] (SV_ID=5)"
+
+  .MaxPotValue[2]:
+    @datatype: uWord
+    @default: 3192
+    @description: "MaxPotValue[SadID] (SV_ID=5)"
+
+  .MinPotValue[1]:
+    @datatype: uWord
+    @default: 3
+    @description: "MinPotValue[SadID] (SV_ID=5)"
+
+  .MinPotValue[2]:
+    @datatype: uWord
+    @default: 3
+    @description: "MinPotValue[SadID] (SV_ID=5)"
+
+  .RadToStepScaleFactor:
+    @datatype: dReal
+    @default: 1 / 0.00625 / DEG_2_RAD
+    @description: "RadToStepScaleFactor, Conversion factor from rad to SAD steps, step/rad Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 08/28/2019, Secion 6.2 (SV_ID=5)"
+
+  .PotFilterA1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterA1 (SV_ID=5)"
+
+  .PotFilterB1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterB1 Ref: Seraphim SADA DD, SERAPHIM-RSZ-DD-0001 Issue 1.0 10.01.2019, Secion 5.3.3.5 MAINPOT, REDPOT PotDeadbandSize[SadID][PotID], Nominally step once every 10 cycles (1Hz), rad (SV_ID=5)"
+
+  .PotDeadbandSize[1][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=5)"
+
+  .PotDeadbandSize[1][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=5)"
+
+  .PotDeadbandSize[2][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=5)"
+
+  .PotDeadbandSize[2][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=5)"
+
+  .PotDeadbandMargin[1][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=5)"
+
+  .PotDeadbandMargin[1][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=5)"
+
+  .PotDeadbandMargin[2][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=5)"
+
+  .PotDeadbandMargin[2][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=5)"
+
+  .AngleCtrlDeadband:
+    @datatype: dReal
+    @default: 0.00417 * 10 * DEG_2_RAD
+    @description: "AngleCtrlDeadband, Nominally step once every 10 cycles (1Hz), rad (SV_ID=5)"
+
+  .MedModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.00417 * DEG_2_RAD
+    @description: "MedModeLoThr, Error low threshold to use Medium Motor Mode, rad ( sized to fall behind up to two Low Mode 1Hz cycle's rotation beyond the deadband ) (SV_ID=5)"
+
+  .HighModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.2 * DEG_2_RAD
+    @description: "HighModeLoThr, Error low threshold to use High Motor Mode, rad ( max rotation of Medium Mode in 2 1Hz cycles ) (SV_ID=5)"
+
+  .MaxSteps[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MaxSteps, Maximum number of steps per control cycle, [HOLD_MODE, LOW_MODE, MED_MODE, HIGH_MODE] (SV_ID=5)"
+
+  .MaxSteps[2]:
+    @datatype: uWord
+    @default: (uWord) (0.00417/0.00625*77/80)
+    @description: "( sized as rotation rate [deg/sec] / deg per step * 77 / 80 minor frames) (SV_ID=5)"
+
+  .MaxSteps[3]:
+    @datatype: uWord
+    @default: (uWord) (0.2/0.00625*77/80)
+    @description: "Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.8.4.1.1 (SV_ID=5)"
+
+  .MaxSteps[4]:
+    @datatype: uWord
+    @default: (uWord) (1.0/0.00625*77/80)
+    @description: "(SV_ID=5)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0x0400
+    @description: "CycleMask, SAD Command Cycle Mask, Cycle 10 (minor frame 77) (SV_ID=5)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, SAD Frame Mask, Every Frame 1 Hz (SV_ID=5)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=5)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3
+    @description: "SADE power off counter initial value, SAD Cycles (SV_ID=5)"
+
+  .WarmupTime:
+    @datatype: dReal
+    @default: 25
+    @description: "WarmupTime, Duration for SADE warmup period, SADE cycles Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.5.1 UseHighInAcsMode, Flag to allow High Motor Mode for each ACS Mode (SV_ID=5)"
+
+  .UseHighInAcsMode[1]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Standby (SV_ID=5)"
+
+  .UseHighInAcsMode[2]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "RateNulling (SV_ID=5)"
+
+  .UseHighInAcsMode[3]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunAcquisition (SV_ID=5)"
+
+  .UseHighInAcsMode[4]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunPointing (SV_ID=5)"
+
+  .UseHighInAcsMode[5]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "DeltaV (SV_ID=5)"
+
+  .UseHighInAcsMode[6]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Normal (SV_ID=5)"
+
+  .UseHighInAcsMode[7]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Target Pointing (SV_ID=5)"
+
+  .UseHighInAcsMode[8]:
+    @datatype: uByte
+    @default: FALSE
+    @description: "Mission (SV_ID=5)"
+
+  .AngleErrorThreshold:
+    @datatype: dReal
+    @default: 20.0 * DEG_2_RAD
+    @description: "Fdc AngleErrorThreshold, Maximum angle error between commanded and measured angle, radians (SV_ID=5)"
+
+  .SunAngleErrorThreshold:
+    @datatype: dReal
+    @default: 25.0 * DEG_2_RAD
+    @description: "SunAngleErrorThreshold, Maximum angle error between SA and sun, radians (SV_ID=5)"
+
+  .PotAngleErrorCnt:
+    @datatype: uWord
+    @default: 60
+    @description: "PotAngleErrorCnt, Pot Angle Error counter initial value, SAD Cycles (SV_ID=5)"
+
+  .SunAngleErrorCnt:
+    @datatype: uWord
+    @default: 15*60
+    @description: "SunAngleErrCnt, Sun Angle Error counter initial value, SAD Cycles (SV_ID=5)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 20
+    @description: "PowerStatusOffCnt, SADE Power Status Off counter initial value, SAD Cycles (SV_ID=5)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=5)"
+
+  .DcmBdyToSad[1]:
+    @datatype: uMatrix
+    @default: { { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=6)"
+
+  .DcmBdyToSad[2]:
+    @datatype: uMatrix
+    @default: { { { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=6)"
+
+  .SadRotDir[1]:
+    @datatype: dReal
+    @default: 1
+    @description: "SadRotDir Ref: SADA FM Calibration Report FOXHOUND-RSS-RP-0036 rev. 1.0, SADE FM005 Cal. Params Table 7.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=6)"
+
+  .SadRotDir[2]:
+    @datatype: dReal
+    @default: -1
+    @description: "SadRotDir Ref: SADA FM Calibration Report FOXHOUND-RSS-RP-0036 rev. 1.0, SADE FM005 Cal. Params Table 7.1.4.1 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=6)"
+
+  .PotOffset[1][1]:
+    @datatype: uWord
+    @default: 28871
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=6)"
+
+  .PotOffset[1][2]:
+    @datatype: uWord
+    @default: 57549
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=6)"
+
+  .PotOffset[2][1]:
+    @datatype: uWord
+    @default: 28968
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=6)"
+
+  .PotOffset[2][2]:
+    @datatype: uWord
+    @default: 260
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=6)"
+
+  .ElecTravel[1][1]:
+    @datatype: uWord
+    @default: 57169
+    @description: "SAD2 (SV_ID=6)"
+
+  .ElecTravel[1][2]:
+    @datatype: uWord
+    @default: 57174
+    @description: "SAD2 (SV_ID=6)"
+
+  .ElecTravel[2][1]:
+    @datatype: uWord
+    @default: 57190
+    @description: "SAD2 (SV_ID=6)"
+
+  .ElecTravel[2][2]:
+    @datatype: uWord
+    @default: 57182
+    @description: "SAD2 (SV_ID=6)"
+
+  .MaxPotValue[1]:
+    @datatype: uWord
+    @default: 3090
+    @description: "MaxPotValue[SadID] (SV_ID=6)"
+
+  .MaxPotValue[2]:
+    @datatype: uWord
+    @default: 3135
+    @description: "MaxPotValue[SadID] (SV_ID=6)"
+
+  .MinPotValue[1]:
+    @datatype: uWord
+    @default: 3
+    @description: "MinPotValue[SadID] (SV_ID=6)"
+
+  .MinPotValue[2]:
+    @datatype: uWord
+    @default: 3
+    @description: "MinPotValue[SadID] (SV_ID=6)"
+
+  .RadToStepScaleFactor:
+    @datatype: dReal
+    @default: 1 / 0.00625 / DEG_2_RAD
+    @description: "RadToStepScaleFactor, Conversion factor from rad to SAD steps, step/rad Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 08/28/2019, Secion 6.2 (SV_ID=6)"
+
+  .PotFilterA1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterA1 (SV_ID=6)"
+
+  .PotFilterB1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterB1 Ref: Seraphim SADA DD, SERAPHIM-RSZ-DD-0001 Issue 1.0 10.01.2019, Secion 5.3.3.5 MAINPOT, REDPOT PotDeadbandSize[SadID][PotID], Nominally step once every 10 cycles (1Hz), rad (SV_ID=6)"
+
+  .PotDeadbandSize[1][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=6)"
+
+  .PotDeadbandSize[1][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=6)"
+
+  .PotDeadbandSize[2][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=6)"
+
+  .PotDeadbandSize[2][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=6)"
+
+  .PotDeadbandMargin[1][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=6)"
+
+  .PotDeadbandMargin[1][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=6)"
+
+  .PotDeadbandMargin[2][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=6)"
+
+  .PotDeadbandMargin[2][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=6)"
+
+  .AngleCtrlDeadband:
+    @datatype: dReal
+    @default: 0.00417 * 10 * DEG_2_RAD
+    @description: "AngleCtrlDeadband, Nominally step once every 10 cycles (1Hz), rad (SV_ID=6)"
+
+  .MedModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.00417 * DEG_2_RAD
+    @description: "MedModeLoThr, Error low threshold to use Medium Motor Mode, rad ( sized to fall behind up to two Low Mode 1Hz cycle's rotation beyond the deadband ) (SV_ID=6)"
+
+  .HighModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.2 * DEG_2_RAD
+    @description: "HighModeLoThr, Error low threshold to use High Motor Mode, rad ( max rotation of Medium Mode in 2 1Hz cycles ) (SV_ID=6)"
+
+  .MaxSteps[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MaxSteps, Maximum number of steps per control cycle, [HOLD_MODE, LOW_MODE, MED_MODE, HIGH_MODE] (SV_ID=6)"
+
+  .MaxSteps[2]:
+    @datatype: uWord
+    @default: (uWord) (0.00417/0.00625*77/80)
+    @description: "( sized as rotation rate [deg/sec] / deg per step * 77 / 80 minor frames) (SV_ID=6)"
+
+  .MaxSteps[3]:
+    @datatype: uWord
+    @default: (uWord) (0.2/0.00625*77/80)
+    @description: "Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.8.4.1.1 (SV_ID=6)"
+
+  .MaxSteps[4]:
+    @datatype: uWord
+    @default: (uWord) (1.0/0.00625*77/80)
+    @description: "(SV_ID=6)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0x0400
+    @description: "CycleMask, SAD Command Cycle Mask, Cycle 10 (minor frame 77) (SV_ID=6)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, SAD Frame Mask, Every Frame 1 Hz (SV_ID=6)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=6)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3
+    @description: "SADE power off counter initial value, SAD Cycles (SV_ID=6)"
+
+  .WarmupTime:
+    @datatype: dReal
+    @default: 25
+    @description: "WarmupTime, Duration for SADE warmup period, SADE cycles Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.5.1 UseHighInAcsMode, Flag to allow High Motor Mode for each ACS Mode (SV_ID=6)"
+
+  .UseHighInAcsMode[1]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Standby (SV_ID=6)"
+
+  .UseHighInAcsMode[2]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "RateNulling (SV_ID=6)"
+
+  .UseHighInAcsMode[3]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunAcquisition (SV_ID=6)"
+
+  .UseHighInAcsMode[4]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunPointing (SV_ID=6)"
+
+  .UseHighInAcsMode[5]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "DeltaV (SV_ID=6)"
+
+  .UseHighInAcsMode[6]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Normal (SV_ID=6)"
+
+  .UseHighInAcsMode[7]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Target Pointing (SV_ID=6)"
+
+  .UseHighInAcsMode[8]:
+    @datatype: uByte
+    @default: FALSE
+    @description: "Mission (SV_ID=6)"
+
+  .AngleErrorThreshold:
+    @datatype: dReal
+    @default: 20.0 * DEG_2_RAD
+    @description: "Fdc AngleErrorThreshold, Maximum angle error between commanded and measured angle, radians (SV_ID=6)"
+
+  .SunAngleErrorThreshold:
+    @datatype: dReal
+    @default: 25.0 * DEG_2_RAD
+    @description: "SunAngleErrorThreshold, Maximum angle error between SA and sun, radians (SV_ID=6)"
+
+  .PotAngleErrorCnt:
+    @datatype: uWord
+    @default: 60
+    @description: "PotAngleErrorCnt, Pot Angle Error counter initial value, SAD Cycles (SV_ID=6)"
+
+  .SunAngleErrorCnt:
+    @datatype: uWord
+    @default: 15*60
+    @description: "SunAngleErrCnt, Sun Angle Error counter initial value, SAD Cycles (SV_ID=6)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 20
+    @description: "PowerStatusOffCnt, SADE Power Status Off counter initial value, SAD Cycles (SV_ID=6)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=6)"
+
+  .DcmBdyToSad[1]:
+    @datatype: uMatrix
+    @default: { { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=ELSE)"
+
+  .DcmBdyToSad[2]:
+    @datatype: uMatrix
+    @default: { { { -1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } } }
+    @description: "(SV_ID=ELSE)"
+
+  .SadRotDir[1]:
+    @datatype: dReal
+    @default: 1
+    @description: "SadRotDir Ref: SADE ICD SERAPHIM-NT-ICD-1000 Rev. 5 Section 5.8.4.1.3 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=ELSE)"
+
+  .SadRotDir[2]:
+    @datatype: dReal
+    @default: -1
+    @description: "SadRotDir Ref: SADE ICD SERAPHIM-NT-ICD-1000 Rev. 5 Section 5.8.4.1.3 MAINPOT, REDPOT PotOffset[SadID][PotID] (SV_ID=ELSE)"
+
+  .PotOffset[1][1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=ELSE)"
+
+  .PotOffset[1][2]:
+    @datatype: uWord
+    @default: 28800
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=ELSE)"
+
+  .PotOffset[2][1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=ELSE)"
+
+  .PotOffset[2][2]:
+    @datatype: uWord
+    @default: 28800
+    @description: "SAD2 MAINPOT, REDPOT ElecTravel[SadID][PotID] (SV_ID=ELSE)"
+
+  .ElecTravel[1][1]:
+    @datatype: uWord
+    @default: 57599
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .ElecTravel[1][2]:
+    @datatype: uWord
+    @default: 57599
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .ElecTravel[2][1]:
+    @datatype: uWord
+    @default: 57599
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .ElecTravel[2][2]:
+    @datatype: uWord
+    @default: 57599
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .MaxPotValue[1]:
+    @datatype: uWord
+    @default: 3680
+    @description: "MaxPotValue[SadID] (SV_ID=ELSE)"
+
+  .MaxPotValue[2]:
+    @datatype: uWord
+    @default: 3680
+    @description: "MaxPotValue[SadID] (SV_ID=ELSE)"
+
+  .MinPotValue[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MinPotValue[SadID] (SV_ID=ELSE)"
+
+  .MinPotValue[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "MinPotValue[SadID] (SV_ID=ELSE)"
+
+  .RadToStepScaleFactor:
+    @datatype: dReal
+    @default: 1 / 0.00625 / DEG_2_RAD
+    @description: "RadToStepScaleFactor, Conversion factor from rad to SAD steps, step/rad Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 08/28/2019, Secion 6.2 (SV_ID=ELSE)"
+
+  .PotFilterA1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterA1 (SV_ID=ELSE)"
+
+  .PotFilterB1:
+    @datatype: dReal
+    @default: 0.5
+    @description: "PotFilterB1 Ref: Seraphim SADA DD, SERAPHIM-RSZ-DD-0001 Issue 1.0 10.01.2019, Secion 5.3.3.5 MAINPOT, REDPOT PotDeadbandSize[SadID][PotID], Nominally step once every 10 cycles (1Hz), rad (SV_ID=ELSE)"
+
+  .PotDeadbandSize[1][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=ELSE)"
+
+  .PotDeadbandSize[1][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=ELSE)"
+
+  .PotDeadbandSize[2][1]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=ELSE)"
+
+  .PotDeadbandSize[2][2]:
+    @datatype: dReal
+    @default: 3.5*DEG_2_RAD
+    @description: "SAD2 MAINPOT, REDPOT PotDeadbandMargin[SadID][PotID], Pot Deadband Margin, rad (SV_ID=ELSE)"
+
+  .PotDeadbandMargin[1][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .PotDeadbandMargin[1][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .PotDeadbandMargin[2][1]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .PotDeadbandMargin[2][2]:
+    @datatype: dReal
+    @default: 1*DEG_2_RAD
+    @description: "SAD2 (SV_ID=ELSE)"
+
+  .AngleCtrlDeadband:
+    @datatype: dReal
+    @default: 0.00417 * 10 * DEG_2_RAD
+    @description: "AngleCtrlDeadband, Nominally step once every 10 cycles (1Hz), rad (SV_ID=ELSE)"
+
+  .MedModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.00417 * DEG_2_RAD
+    @description: "MedModeLoThr, Error low threshold to use Medium Motor Mode, rad ( sized to fall behind up to two Low Mode 1Hz cycle's rotation beyond the deadband ) (SV_ID=ELSE)"
+
+  .HighModeLoThr:
+    @datatype: dReal
+    @default: 2 * 0.2 * DEG_2_RAD
+    @description: "HighModeLoThr, Error low threshold to use High Motor Mode, rad ( max rotation of Medium Mode in 2 1Hz cycles ) (SV_ID=ELSE)"
+
+  .MaxSteps[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "MaxSteps, Maximum number of steps per control cycle, [HOLD_MODE, LOW_MODE, MED_MODE, HIGH_MODE] (SV_ID=ELSE)"
+
+  .MaxSteps[2]:
+    @datatype: uWord
+    @default: (uWord) (0.00417/0.00625*77/80)
+    @description: "( sized as rotation rate [deg/sec] / deg per step * 77 / 80 minor frames) (SV_ID=ELSE)"
+
+  .MaxSteps[3]:
+    @datatype: uWord
+    @default: (uWord) (0.2/0.00625*77/80)
+    @description: "Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.8.4.1.1 (SV_ID=ELSE)"
+
+  .MaxSteps[4]:
+    @datatype: uWord
+    @default: (uWord) (1.0/0.00625*77/80)
+    @description: "(SV_ID=ELSE)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0x0400
+    @description: "CycleMask, SAD Command Cycle Mask, Cycle 10 (minor frame 77) (SV_ID=ELSE)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, SAD Frame Mask, Every Frame 1 Hz (SV_ID=ELSE)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=ELSE)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3
+    @description: "SADE power off counter initial value, SAD Cycles (SV_ID=ELSE)"
+
+  .WarmupTime:
+    @datatype: dReal
+    @default: 25
+    @description: "WarmupTime, Duration for SADE warmup period, SADE cycles Ref: Seraphim SADE ICD, SERAPHIM-NT-ICD-1000 Issue 5.0 28.08.2019, Secion 5.5.1 UseHighInAcsMode, Flag to allow High Motor Mode for each ACS Mode (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[1]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Standby (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[2]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "RateNulling (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[3]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunAcquisition (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[4]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "SunPointing (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[5]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "DeltaV (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[6]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Normal (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[7]:
+    @datatype: uByte
+    @default: TRUE
+    @description: "Target Pointing (SV_ID=ELSE)"
+
+  .UseHighInAcsMode[8]:
+    @datatype: uByte
+    @default: FALSE
+    @description: "Mission (SV_ID=ELSE)"
+
+  .AngleErrorThreshold:
+    @datatype: dReal
+    @default: 20.0 * DEG_2_RAD
+    @description: "Fdc AngleErrorThreshold, Maximum angle error between commanded and measured angle, radians (SV_ID=ELSE)"
+
+  .SunAngleErrorThreshold:
+    @datatype: dReal
+    @default: 25.0 * DEG_2_RAD
+    @description: "SunAngleErrorThreshold, Maximum angle error between SA and sun, radians (SV_ID=ELSE)"
+
+  .PotAngleErrorCnt:
+    @datatype: uWord
+    @default: 60
+    @description: "PotAngleErrorCnt, Pot Angle Error counter initial value, SAD Cycles (SV_ID=ELSE)"
+
+  .SunAngleErrorCnt:
+    @datatype: uWord
+    @default: 15*60
+    @description: "SunAngleErrCnt, Sun Angle Error counter initial value, SAD Cycles (SV_ID=ELSE)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: 20
+    @description: "PowerStatusOffCnt, SADE Power Status Off counter initial value, SAD Cycles (SV_ID=ELSE)"
+
+  .Spare:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare (SV_ID=ELSE)"
+
+}
+
+table ac_sceph_table_type {
+  @buildstruct!
+  .ScEphDtThr:
+    @datatype: dReal
+    @default: 20.0
+    @description: "ScEphDtThr For Propagating Eph, sec"
+
+  .ScEphTimeWarnHiThr:
+    @datatype: dReal
+    @default: 1.0 * DAY_2_SEC
+    @description: "ScEphTimeWarnHiThr For Eph UpdateTime Check, sec"
+
+  .RscMagThr:
+    @datatype: dReal
+    @default: 6378136.6
+    @description: "RscMagThr, m"
+
+  .PositionLmt:
+    @datatype: dReal
+    @default: 150.0 * 1000.0
+    @description: "PositionLmt For Accepting New EPV, m"
+
+  .VelocityLmt:
+    @datatype: dReal
+    @default: 1.5 * 1000.0
+    @description: "VelocityLmt For Accepting New EPV, m/s"
+
+  .SunMu:
+    @datatype: dReal
+    @default: 1.32712442079556E+20
+    @description: "SunMu (m^3/s^2)"
+
+  .MoonMu:
+    @datatype: dReal
+    @default: 4.90279918585524E+12
+    @description: "MoonMu (m^3/s^2)"
+
+  .ScMassLim[1]:
+    @datatype: dReal
+    @default: 764.09939-50
+    @description: "ScMassLim, kg, rev J Mass Properties"
+
+  .ScMassLim[2]:
+    @datatype: dReal
+    @default: 897.40621+50
+    @description: "ScMassLim, kg, rev J Mass Properties"
+
+  .MassInit:
+    @datatype: dReal
+    @default: 897.39939
+    @description: "MassInit Initial Spacecraft Mass, kg, rev J Mass Properties"
+
+  .ScCmInit:
+    @datatype: uVector
+    @default: { -0.02304, -0.00087, 1.06976 }
+    @description: "ScCmInit Initial Spacecraft Center of Mass (m), rev J Mass Properties MOL"
+
+  .ScCmLimX[1]:
+    @datatype: dReal
+    @default: -0.05005
+    @description: "ScCmLimX Spacecraft CM X Limits (m), rev J Mass Properties +/- 25 mm"
+
+  .ScCmLimX[2]:
+    @datatype: dReal
+    @default: 0.02501
+    @description: "ScCmLimX Spacecraft CM X Limits (m), rev J Mass Properties +/- 25 mm"
+
+  .ScCmLimY[1]:
+    @datatype: dReal
+    @default: -0.02595
+    @description: "ScCmLimY Spacecraft CM Y Limits (m), rev J Mass Properties +/- 25 mm"
+
+  .ScCmLimY[2]:
+    @datatype: dReal
+    @default: 0.02485
+    @description: "ScCmLimY Spacecraft CM Y Limits (m), rev J Mass Properties +/- 25 mm"
+
+  .ScCmLimZ[1]:
+    @datatype: dReal
+    @default: 0.93031
+    @description: "ScCmLimZ Spacecraft CM Z Limits (m), rev J Mass Properties +/- 100 mm"
+
+  .ScCmLimZ[2]:
+    @datatype: dReal
+    @default: 1.26569
+    @description: "ScCmLimZ Spacecraft CM Z Limits (m), rev J Mass Properties +/- 100 mm"
+
+  .EarthRadius:
+    @datatype: dReal
+    @default: 6.37813660000000E+06
+    @description: "EarthRadius At Equator, m"
+
+  .EarthMu:
+    @datatype: dReal
+    @default: 3.98600441800000E+14
+    @description: "EarthMu (m^3/s^2)"
+
+  .EarthEccentricity:
+    @datatype: dReal
+    @default: 0.081819300876173
+    @description: "Earth Eccentricity Received from Tim Berman - 9/28/2018 From JGM-3 Geopotential Model ..."
+
+  .J2:
+    @datatype: dReal
+    @default: 1.08262668355315E-03
+    @description: "J2 Zonal Harmonic"
+
+  .J3:
+    @datatype: dReal
+    @default: -2.53265648533224E-06
+    @description: "J3 Zonal Harmonic"
+
+  .J4:
+    @datatype: dReal
+    @default: -1.61962159136700E-06
+    @description: "J4 Zonal Harmonic"
+
+  .CS22:
+    @datatype: dReal
+    @default: 1.81543019473806E-06
+    @description: "CS22, Sectoral Harmonic, Sqrt (C22^2 + S22^2)"
+
+  .ANG22:
+    @datatype: dReal
+    @default: -5.21112788884155E-01
+    @description: "ANG22, Result Of atan2(S22, C22), rad,"
+
+  .DvEstAutoSelAccelThr:
+    @datatype: dReal
+    @default: 0.01
+    @description: "DeltaV Estimate Auto Select Acceleration Threshold, m/s^2"
+
+  .DeltaPropTime:
+    @datatype: dReal
+    @default: 0.5
+    @description: "Goods ... DeltaPropTime (sec)"
+
+  .PrecisionThr:
+    @datatype: uWord
+    @default: PRECISION_LOW
+    @description: "PrecisionThr (an_precision_enum)"
+
+  .QualityThr:
+    @datatype: uWord
+    @default: QUALITY_LOW
+    @description: "QualityThr (an_quality_enum)"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .SpoofUnusedReasonMask:
+    @datatype: uDword
+    @default: 0xFFFFFFFF
+    @description: "SpoofUnusedReasonMask"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "Spare"
+
+}
+
+table ac_solar_table_type {
+  @buildstruct!
+  .SMSE0:
+    @datatype: dReal
+    @default: 23.439279 * DEG_2_RAD
+    @description: "SMSE0"
+
+  .SMSE1:
+    @datatype: dReal
+    @default: 0.00000040 * DEG_2_RAD
+    @description: "SMSE1"
+
+  .SMMA1:
+    @datatype: dReal
+    @default: 357.528 * DEG_2_RAD
+    @description: "SMMA1"
+
+  .SMMA2:
+    @datatype: dReal
+    @default: 0.9856003 * DEG_2_RAD
+    @description: "SMMA2"
+
+  .SMML1:
+    @datatype: dReal
+    @default: 280.460 * DEG_2_RAD
+    @description: "SMML1, 280.47169"
+
+  .SMML2:
+    @datatype: dReal
+    @default: 0.9856474 * DEG_2_RAD
+    @description: "SMML2"
+
+  .SMEL1:
+    @datatype: dReal
+    @default: 1.915 * DEG_2_RAD
+    @description: "SMEL1"
+
+  .SMEL2:
+    @datatype: dReal
+    @default: 0.020 * DEG_2_RAD
+    @description: "SMEL2"
+
+  .SMGPL:
+    @datatype: dReal
+    @default: 5028.7800 * ARCSEC_2_RAD / CENTURY_2_DAY
+    @description: "SMGPL"
+
+  .SMR1:
+    @datatype: dReal
+    @default: 1.00014
+    @description: "SMR1"
+
+  .SMR2:
+    @datatype: dReal
+    @default: 0.01671
+    @description: "SMR2"
+
+  .SMR3:
+    @datatype: dReal
+    @default: 0.00014
+    @description: "SMR3"
+
+  .RS0:
+    @datatype: dReal
+    @default: 149597871465.6
+    @description: "RS0"
+
+  .ComputeVelocityCnt:
+    @datatype: dword
+    @default: 30
+    @description: "ComputeVelocityCnt"
+
+  .SpareDword:
+    @datatype: dword
+    @default: 0
+    @description: "Pad structure"
+
+}
+
+table ac_sta_table_type {
+  @buildstruct!
+  .StaMesDelay[1]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=1)"
+
+  .StaMesDelay[2]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=1)"
+
+  .IruToAcDelay:
+    @datatype: dReal
+    @default: { 0.0 }
+    @description: "IruToAcDelay (sec) (SV_ID=1)"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: { 3.0 }
+    @description: "WarmUpTime (sec) (SV_ID=1)"
+
+  .CoiScaleFactor:
+    @datatype: dReal
+    @default: { 2.0E-05 }
+    @description: "CoiScaleFactor (sec/count) (SV_ID=1)"
+
+  .LinearVelocityLsbX:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbX (m/s/count) (SV_ID=1)"
+
+  .LinearVelocityLsbY:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbY (m/s/count) (SV_ID=1)"
+
+  .LinearVelocityLsbZ:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbZ (m/s/count) (SV_ID=1)"
+
+  .XYQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "XYQualityIndexLsb (arcsec/count) (SV_ID=1)"
+
+  .ZQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "ZQualityIndexLsb (arcsec/count) (SV_ID=1)"
+
+  .QBdyToSta[1]:
+    @datatype: uQuaternion
+    @default: { 0.595752843342, -0.241359981871, 0.709990316835, 0.287641598987 }
+    @description: "QBdyToSta[STA1] (SV_ID=1)"
+
+  .QBdyToSta[2]:
+    @datatype: uQuaternion
+    @default: { 0.241359981871, -0.595752843342, 0.287641598987, 0.709990316835 }
+    @description: "(SV_ID=1)"
+
+  .StaNoiseCov[1]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=1)"
+
+  .StaNoiseCov[2]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=1)"
+
+  .BoresightSta[1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=1)"
+
+  .BoresightSta[2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=1)"
+
+  .QualityIndexThr[1]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=1)"
+
+  .QualityIndexThr[2]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=1)"
+
+  .VelCmdModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_ACQ_MODE }
+    @description: "VelCmdModeMin (SV_ID=1)"
+
+  .VelCmdModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "VelCmdModeMax (SV_ID=1)"
+
+  .SecondStatusMask:
+    @datatype: uWord
+    @default: { 0x0070 }
+    @description: "SecondStatusMask (Big Endian Bit order) (SV_ID=1)"
+
+  .SecondStatusDesired:
+    @datatype: uWord
+    @default: { 0x0050 }
+    @description: "SecondStatusDesired (Big Endian Bit order) (SV_ID=1)"
+
+  .HealthStatusMask:
+    @datatype: uWord
+    @default: { 0x0FFE }
+    @description: "HealthStatusMask (Big Endian Bit order) (SV_ID=1)"
+
+  .HealtStatusDesired:
+    @datatype: uWord
+    @default: { 0x0000 }
+    @description: "HealthStatusDesired (Big Endian Bit order) (SV_ID=1)"
+
+  .SyntDefOhMask[1]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=1)"
+
+  .SyntDefOhMask[2]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=1)"
+
+  .SyntDefOhDesired[1]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=1)"
+
+  .SyntDefOhDesired[2]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=1)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=1)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_STA_CYCLES
+    @description: "PowerOffCnt, (ACS Cycles) (SV_ID=1)"
+
+  .EarthOccultationThr[1]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=1)"
+
+  .EarthOccultationThr[2]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=1)"
+
+  .SolarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=1)"
+
+  .SolarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=1)"
+
+  .LunarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=1)"
+
+  .LunarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=1)"
+
+  .DataValidityFailCnt[1]:
+    @datatype: uWord
+    @default: 20*NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=1)"
+
+  .DataValidityFailCnt[2]:
+    @datatype: uWord
+    @default: 20 * NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=1)"
+
+  .DataQualityFailCnt[1]:
+    @datatype: uWord
+    @default: 15*MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=1)"
+
+  .DataQualityFailCnt[2]:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=1)"
+
+  .StaDataValidityFailCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "StaDataValidityFailCnt cnt (SV_ID=1)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "PowerStatusOffCnt cnt (SV_ID=1)"
+
+  .OccultationADKFThr:
+    @datatype: uWord
+    @default: { COARSE_CONVERGED }
+    @description: "OccultationADKFThr, (SV_ID=1)"
+
+  .ExpectedOpModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMin[STA1] (SV_ID=1)"
+
+  .ExpectedOpModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMax[STA1] (SV_ID=1)"
+
+  .OhDesiredSeqStatusMin[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=1)"
+
+  .OhDesiredSeqStatusMin[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=1)"
+
+  .OhDesiredSeqStatusMax[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=1)"
+
+  .OhDesiredSeqStatusMax[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=1)"
+
+  .StaCorrectCnt:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "StaCorrectCnt, cnt (SV_ID=1)"
+
+  .StaVerifyCnt:
+    @datatype: uWord
+    @default: 20*NUM_AC_CYCLES
+    @description: "StaVerifyCnt, cnt (SV_ID=1)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=1)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "CycleMask, Cycle 1, 3, 5, ... (5 Hz) (SV_ID=1)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, Every Frame 1 - 15 (SV_ID=1)"
+
+  .VelCmdCycleMask:
+    @datatype: uWord
+    @default: { 0x0400 }
+    @description: "VelCmdCycleMask[STA1], Cycle 3 (1 Hz) (SV_ID=1)"
+
+  .VelCmdFrameMask:
+    @datatype: uWord
+    @default: { 0xFFFE }
+    @description: "VelCmdFrameMask[STA1], Every Frame 1 - 15 (SV_ID=1)"
+
+  .StaMesDelay[1]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=2)"
+
+  .StaMesDelay[2]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=2)"
+
+  .IruToAcDelay:
+    @datatype: dReal
+    @default: { 0.0 }
+    @description: "IruToAcDelay (sec) (SV_ID=2)"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: { 3.0 }
+    @description: "WarmUpTime (sec) (SV_ID=2)"
+
+  .CoiScaleFactor:
+    @datatype: dReal
+    @default: { 2.0E-05 }
+    @description: "CoiScaleFactor (sec/count) (SV_ID=2)"
+
+  .LinearVelocityLsbX:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbX (m/s/count) (SV_ID=2)"
+
+  .LinearVelocityLsbY:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbY (m/s/count) (SV_ID=2)"
+
+  .LinearVelocityLsbZ:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbZ (m/s/count) (SV_ID=2)"
+
+  .XYQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "XYQualityIndexLsb (arcsec/count) (SV_ID=2)"
+
+  .ZQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "ZQualityIndexLsb (arcsec/count) (SV_ID=2)"
+
+  .QBdyToSta[1]:
+    @datatype: uQuaternion
+    @default: { 0.595752843342, -0.241359981871, 0.709990316835, 0.287641598987 }
+    @description: "QBdyToSta[STA1] (SV_ID=2)"
+
+  .QBdyToSta[2]:
+    @datatype: uQuaternion
+    @default: { 0.241359981871, -0.595752843342, 0.287641598987, 0.709990316835 }
+    @description: "(SV_ID=2)"
+
+  .StaNoiseCov[1]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=2)"
+
+  .StaNoiseCov[2]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=2)"
+
+  .BoresightSta[1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=2)"
+
+  .BoresightSta[2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=2)"
+
+  .QualityIndexThr[1]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=2)"
+
+  .QualityIndexThr[2]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=2)"
+
+  .VelCmdModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_ACQ_MODE }
+    @description: "VelCmdModeMin (SV_ID=2)"
+
+  .VelCmdModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "VelCmdModeMax (SV_ID=2)"
+
+  .SecondStatusMask:
+    @datatype: uWord
+    @default: { 0x0070 }
+    @description: "SecondStatusMask (Big Endian Bit order) (SV_ID=2)"
+
+  .SecondStatusDesired:
+    @datatype: uWord
+    @default: { 0x0050 }
+    @description: "SecondStatusDesired (Big Endian Bit order) (SV_ID=2)"
+
+  .HealthStatusMask:
+    @datatype: uWord
+    @default: { 0x0FFE }
+    @description: "HealthStatusMask (Big Endian Bit order) (SV_ID=2)"
+
+  .HealtStatusDesired:
+    @datatype: uWord
+    @default: { 0x0000 }
+    @description: "HealthStatusDesired (Big Endian Bit order) (SV_ID=2)"
+
+  .SyntDefOhMask[1]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=2)"
+
+  .SyntDefOhMask[2]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=2)"
+
+  .SyntDefOhDesired[1]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=2)"
+
+  .SyntDefOhDesired[2]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=2)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=2)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_STA_CYCLES
+    @description: "PowerOffCnt, (ACS Cycles) (SV_ID=2)"
+
+  .EarthOccultationThr[1]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=2)"
+
+  .EarthOccultationThr[2]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=2)"
+
+  .SolarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=2)"
+
+  .SolarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=2)"
+
+  .LunarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=2)"
+
+  .LunarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=2)"
+
+  .DataValidityFailCnt[1]:
+    @datatype: uWord
+    @default: 20*NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=2)"
+
+  .DataValidityFailCnt[2]:
+    @datatype: uWord
+    @default: 20 * NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=2)"
+
+  .DataQualityFailCnt[1]:
+    @datatype: uWord
+    @default: 15*MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=2)"
+
+  .DataQualityFailCnt[2]:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=2)"
+
+  .StaDataValidityFailCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "StaDataValidityFailCnt cnt (SV_ID=2)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "PowerStatusOffCnt cnt (SV_ID=2)"
+
+  .OccultationADKFThr:
+    @datatype: uWord
+    @default: { COARSE_CONVERGED }
+    @description: "OccultationADKFThr, (SV_ID=2)"
+
+  .ExpectedOpModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMin[STA1] (SV_ID=2)"
+
+  .ExpectedOpModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMax[STA1] (SV_ID=2)"
+
+  .OhDesiredSeqStatusMin[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=2)"
+
+  .OhDesiredSeqStatusMin[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=2)"
+
+  .OhDesiredSeqStatusMax[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=2)"
+
+  .OhDesiredSeqStatusMax[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=2)"
+
+  .StaCorrectCnt:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "StaCorrectCnt, cnt (SV_ID=2)"
+
+  .StaVerifyCnt:
+    @datatype: uWord
+    @default: 20*NUM_AC_CYCLES
+    @description: "StaVerifyCnt, cnt (SV_ID=2)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=2)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "CycleMask, Cycle 1, 3, 5, ... (5 Hz) (SV_ID=2)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, Every Frame 1 - 15 (SV_ID=2)"
+
+  .VelCmdCycleMask:
+    @datatype: uWord
+    @default: { 0x0400 }
+    @description: "VelCmdCycleMask[STA1], Cycle 3 (1 Hz) (SV_ID=2)"
+
+  .VelCmdFrameMask:
+    @datatype: uWord
+    @default: { 0xFFFE }
+    @description: "VelCmdFrameMask[STA1], Every Frame 1 - 15 (SV_ID=2)"
+
+  .StaMesDelay[1]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=3)"
+
+  .StaMesDelay[2]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=3)"
+
+  .IruToAcDelay:
+    @datatype: dReal
+    @default: { 0.0 }
+    @description: "IruToAcDelay (sec) (SV_ID=3)"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: { 3.0 }
+    @description: "WarmUpTime (sec) (SV_ID=3)"
+
+  .CoiScaleFactor:
+    @datatype: dReal
+    @default: { 2.0E-05 }
+    @description: "CoiScaleFactor (sec/count) (SV_ID=3)"
+
+  .LinearVelocityLsbX:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbX (m/s/count) (SV_ID=3)"
+
+  .LinearVelocityLsbY:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbY (m/s/count) (SV_ID=3)"
+
+  .LinearVelocityLsbZ:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbZ (m/s/count) (SV_ID=3)"
+
+  .XYQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "XYQualityIndexLsb (arcsec/count) (SV_ID=3)"
+
+  .ZQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "ZQualityIndexLsb (arcsec/count) (SV_ID=3)"
+
+  .QBdyToSta[1]:
+    @datatype: uQuaternion
+    @default: { 0.595752843342, -0.241359981871, 0.709990316835, 0.287641598987 }
+    @description: "QBdyToSta[STA1] (SV_ID=3)"
+
+  .QBdyToSta[2]:
+    @datatype: uQuaternion
+    @default: { 0.241359981871, -0.595752843342, 0.287641598987, 0.709990316835 }
+    @description: "(SV_ID=3)"
+
+  .StaNoiseCov[1]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=3)"
+
+  .StaNoiseCov[2]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=3)"
+
+  .BoresightSta[1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=3)"
+
+  .BoresightSta[2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=3)"
+
+  .QualityIndexThr[1]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=3)"
+
+  .QualityIndexThr[2]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=3)"
+
+  .VelCmdModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_ACQ_MODE }
+    @description: "VelCmdModeMin (SV_ID=3)"
+
+  .VelCmdModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "VelCmdModeMax (SV_ID=3)"
+
+  .SecondStatusMask:
+    @datatype: uWord
+    @default: { 0x0070 }
+    @description: "SecondStatusMask (Big Endian Bit order) (SV_ID=3)"
+
+  .SecondStatusDesired:
+    @datatype: uWord
+    @default: { 0x0050 }
+    @description: "SecondStatusDesired (Big Endian Bit order) (SV_ID=3)"
+
+  .HealthStatusMask:
+    @datatype: uWord
+    @default: { 0x0FFE }
+    @description: "HealthStatusMask (Big Endian Bit order) (SV_ID=3)"
+
+  .HealtStatusDesired:
+    @datatype: uWord
+    @default: { 0x0000 }
+    @description: "HealthStatusDesired (Big Endian Bit order) (SV_ID=3)"
+
+  .SyntDefOhMask[1]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=3)"
+
+  .SyntDefOhMask[2]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=3)"
+
+  .SyntDefOhDesired[1]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=3)"
+
+  .SyntDefOhDesired[2]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=3)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=3)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_STA_CYCLES
+    @description: "PowerOffCnt, (ACS Cycles) (SV_ID=3)"
+
+  .EarthOccultationThr[1]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=3)"
+
+  .EarthOccultationThr[2]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=3)"
+
+  .SolarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=3)"
+
+  .SolarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=3)"
+
+  .LunarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=3)"
+
+  .LunarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=3)"
+
+  .DataValidityFailCnt[1]:
+    @datatype: uWord
+    @default: 20*NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=3)"
+
+  .DataValidityFailCnt[2]:
+    @datatype: uWord
+    @default: 20 * NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=3)"
+
+  .DataQualityFailCnt[1]:
+    @datatype: uWord
+    @default: 15*MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=3)"
+
+  .DataQualityFailCnt[2]:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=3)"
+
+  .StaDataValidityFailCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "StaDataValidityFailCnt cnt (SV_ID=3)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "PowerStatusOffCnt cnt (SV_ID=3)"
+
+  .OccultationADKFThr:
+    @datatype: uWord
+    @default: { COARSE_CONVERGED }
+    @description: "OccultationADKFThr, (SV_ID=3)"
+
+  .ExpectedOpModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMin[STA1] (SV_ID=3)"
+
+  .ExpectedOpModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMax[STA1] (SV_ID=3)"
+
+  .OhDesiredSeqStatusMin[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=3)"
+
+  .OhDesiredSeqStatusMin[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=3)"
+
+  .OhDesiredSeqStatusMax[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=3)"
+
+  .OhDesiredSeqStatusMax[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=3)"
+
+  .StaCorrectCnt:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "StaCorrectCnt, cnt (SV_ID=3)"
+
+  .StaVerifyCnt:
+    @datatype: uWord
+    @default: 20*NUM_AC_CYCLES
+    @description: "StaVerifyCnt, cnt (SV_ID=3)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=3)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "CycleMask, Cycle 1, 3, 5, ... (5 Hz) (SV_ID=3)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, Every Frame 1 - 15 (SV_ID=3)"
+
+  .VelCmdCycleMask:
+    @datatype: uWord
+    @default: { 0x0400 }
+    @description: "VelCmdCycleMask[STA1], Cycle 3 (1 Hz) (SV_ID=3)"
+
+  .VelCmdFrameMask:
+    @datatype: uWord
+    @default: { 0xFFFE }
+    @description: "VelCmdFrameMask[STA1], Every Frame 1 - 15 (SV_ID=3)"
+
+  .StaMesDelay[1]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=4)"
+
+  .StaMesDelay[2]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=4)"
+
+  .IruToAcDelay:
+    @datatype: dReal
+    @default: { 0.0 }
+    @description: "IruToAcDelay (sec) (SV_ID=4)"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: { 3.0 }
+    @description: "WarmUpTime (sec) (SV_ID=4)"
+
+  .CoiScaleFactor:
+    @datatype: dReal
+    @default: { 2.0E-05 }
+    @description: "CoiScaleFactor (sec/count) (SV_ID=4)"
+
+  .LinearVelocityLsbX:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbX (m/s/count) (SV_ID=4)"
+
+  .LinearVelocityLsbY:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbY (m/s/count) (SV_ID=4)"
+
+  .LinearVelocityLsbZ:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbZ (m/s/count) (SV_ID=4)"
+
+  .XYQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "XYQualityIndexLsb (arcsec/count) (SV_ID=4)"
+
+  .ZQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "ZQualityIndexLsb (arcsec/count) (SV_ID=4)"
+
+  .QBdyToSta[1]:
+    @datatype: uQuaternion
+    @default: { 0.595752843342, -0.241359981871, 0.709990316835, 0.287641598987 }
+    @description: "QBdyToSta[STA1] (SV_ID=4)"
+
+  .QBdyToSta[2]:
+    @datatype: uQuaternion
+    @default: { 0.241359981871, -0.595752843342, 0.287641598987, 0.709990316835 }
+    @description: "(SV_ID=4)"
+
+  .StaNoiseCov[1]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=4)"
+
+  .StaNoiseCov[2]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=4)"
+
+  .BoresightSta[1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=4)"
+
+  .BoresightSta[2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=4)"
+
+  .QualityIndexThr[1]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=4)"
+
+  .QualityIndexThr[2]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=4)"
+
+  .VelCmdModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_ACQ_MODE }
+    @description: "VelCmdModeMin (SV_ID=4)"
+
+  .VelCmdModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "VelCmdModeMax (SV_ID=4)"
+
+  .SecondStatusMask:
+    @datatype: uWord
+    @default: { 0x0070 }
+    @description: "SecondStatusMask (Big Endian Bit order) (SV_ID=4)"
+
+  .SecondStatusDesired:
+    @datatype: uWord
+    @default: { 0x0050 }
+    @description: "SecondStatusDesired (Big Endian Bit order) (SV_ID=4)"
+
+  .HealthStatusMask:
+    @datatype: uWord
+    @default: { 0x0FFE }
+    @description: "HealthStatusMask (Big Endian Bit order) (SV_ID=4)"
+
+  .HealtStatusDesired:
+    @datatype: uWord
+    @default: { 0x0000 }
+    @description: "HealthStatusDesired (Big Endian Bit order) (SV_ID=4)"
+
+  .SyntDefOhMask[1]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=4)"
+
+  .SyntDefOhMask[2]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=4)"
+
+  .SyntDefOhDesired[1]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=4)"
+
+  .SyntDefOhDesired[2]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=4)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=4)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_STA_CYCLES
+    @description: "PowerOffCnt, (ACS Cycles) (SV_ID=4)"
+
+  .EarthOccultationThr[1]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=4)"
+
+  .EarthOccultationThr[2]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=4)"
+
+  .SolarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=4)"
+
+  .SolarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=4)"
+
+  .LunarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=4)"
+
+  .LunarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=4)"
+
+  .DataValidityFailCnt[1]:
+    @datatype: uWord
+    @default: 20*NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=4)"
+
+  .DataValidityFailCnt[2]:
+    @datatype: uWord
+    @default: 20 * NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=4)"
+
+  .DataQualityFailCnt[1]:
+    @datatype: uWord
+    @default: 15*MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=4)"
+
+  .DataQualityFailCnt[2]:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=4)"
+
+  .StaDataValidityFailCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "StaDataValidityFailCnt cnt (SV_ID=4)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "PowerStatusOffCnt cnt (SV_ID=4)"
+
+  .OccultationADKFThr:
+    @datatype: uWord
+    @default: { COARSE_CONVERGED }
+    @description: "OccultationADKFThr, (SV_ID=4)"
+
+  .ExpectedOpModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMin[STA1] (SV_ID=4)"
+
+  .ExpectedOpModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMax[STA1] (SV_ID=4)"
+
+  .OhDesiredSeqStatusMin[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=4)"
+
+  .OhDesiredSeqStatusMin[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=4)"
+
+  .OhDesiredSeqStatusMax[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=4)"
+
+  .OhDesiredSeqStatusMax[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=4)"
+
+  .StaCorrectCnt:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "StaCorrectCnt, cnt (SV_ID=4)"
+
+  .StaVerifyCnt:
+    @datatype: uWord
+    @default: 20*NUM_AC_CYCLES
+    @description: "StaVerifyCnt, cnt (SV_ID=4)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=4)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "CycleMask, Cycle 1, 3, 5, ... (5 Hz) (SV_ID=4)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, Every Frame 1 - 15 (SV_ID=4)"
+
+  .VelCmdCycleMask:
+    @datatype: uWord
+    @default: { 0x0400 }
+    @description: "VelCmdCycleMask[STA1], Cycle 3 (1 Hz) (SV_ID=4)"
+
+  .VelCmdFrameMask:
+    @datatype: uWord
+    @default: { 0xFFFE }
+    @description: "VelCmdFrameMask[STA1], Every Frame 1 - 15 (SV_ID=4)"
+
+  .StaMesDelay[1]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=5)"
+
+  .StaMesDelay[2]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=5)"
+
+  .IruToAcDelay:
+    @datatype: dReal
+    @default: { 0.0 }
+    @description: "IruToAcDelay (sec) (SV_ID=5)"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: { 3.0 }
+    @description: "WarmUpTime (sec) (SV_ID=5)"
+
+  .CoiScaleFactor:
+    @datatype: dReal
+    @default: { 2.0E-05 }
+    @description: "CoiScaleFactor (sec/count) (SV_ID=5)"
+
+  .LinearVelocityLsbX:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbX (m/s/count) (SV_ID=5)"
+
+  .LinearVelocityLsbY:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbY (m/s/count) (SV_ID=5)"
+
+  .LinearVelocityLsbZ:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbZ (m/s/count) (SV_ID=5)"
+
+  .XYQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "XYQualityIndexLsb (arcsec/count) (SV_ID=5)"
+
+  .ZQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "ZQualityIndexLsb (arcsec/count) (SV_ID=5)"
+
+  .QBdyToSta[1]:
+    @datatype: uQuaternion
+    @default: { 0.595752843342, -0.241359981871, 0.709990316835, 0.287641598987 }
+    @description: "QBdyToSta[STA1] (SV_ID=5)"
+
+  .QBdyToSta[2]:
+    @datatype: uQuaternion
+    @default: { 0.241359981871, -0.595752843342, 0.287641598987, 0.709990316835 }
+    @description: "(SV_ID=5)"
+
+  .StaNoiseCov[1]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=5)"
+
+  .StaNoiseCov[2]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=5)"
+
+  .BoresightSta[1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=5)"
+
+  .BoresightSta[2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=5)"
+
+  .QualityIndexThr[1]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=5)"
+
+  .QualityIndexThr[2]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=5)"
+
+  .VelCmdModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_ACQ_MODE }
+    @description: "VelCmdModeMin (SV_ID=5)"
+
+  .VelCmdModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "VelCmdModeMax (SV_ID=5)"
+
+  .SecondStatusMask:
+    @datatype: uWord
+    @default: { 0x0070 }
+    @description: "SecondStatusMask (Big Endian Bit order) (SV_ID=5)"
+
+  .SecondStatusDesired:
+    @datatype: uWord
+    @default: { 0x0050 }
+    @description: "SecondStatusDesired (Big Endian Bit order) (SV_ID=5)"
+
+  .HealthStatusMask:
+    @datatype: uWord
+    @default: { 0x0FFE }
+    @description: "HealthStatusMask (Big Endian Bit order) (SV_ID=5)"
+
+  .HealtStatusDesired:
+    @datatype: uWord
+    @default: { 0x0000 }
+    @description: "HealthStatusDesired (Big Endian Bit order) (SV_ID=5)"
+
+  .SyntDefOhMask[1]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=5)"
+
+  .SyntDefOhMask[2]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=5)"
+
+  .SyntDefOhDesired[1]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=5)"
+
+  .SyntDefOhDesired[2]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=5)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=5)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_STA_CYCLES
+    @description: "PowerOffCnt, (ACS Cycles) (SV_ID=5)"
+
+  .EarthOccultationThr[1]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=5)"
+
+  .EarthOccultationThr[2]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=5)"
+
+  .SolarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=5)"
+
+  .SolarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=5)"
+
+  .LunarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=5)"
+
+  .LunarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=5)"
+
+  .DataValidityFailCnt[1]:
+    @datatype: uWord
+    @default: 20*NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=5)"
+
+  .DataValidityFailCnt[2]:
+    @datatype: uWord
+    @default: 20 * NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=5)"
+
+  .DataQualityFailCnt[1]:
+    @datatype: uWord
+    @default: 15*MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=5)"
+
+  .DataQualityFailCnt[2]:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=5)"
+
+  .StaDataValidityFailCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "StaDataValidityFailCnt cnt (SV_ID=5)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "PowerStatusOffCnt cnt (SV_ID=5)"
+
+  .OccultationADKFThr:
+    @datatype: uWord
+    @default: { COARSE_CONVERGED }
+    @description: "OccultationADKFThr, (SV_ID=5)"
+
+  .ExpectedOpModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMin[STA1] (SV_ID=5)"
+
+  .ExpectedOpModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMax[STA1] (SV_ID=5)"
+
+  .OhDesiredSeqStatusMin[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=5)"
+
+  .OhDesiredSeqStatusMin[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=5)"
+
+  .OhDesiredSeqStatusMax[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=5)"
+
+  .OhDesiredSeqStatusMax[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=5)"
+
+  .StaCorrectCnt:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "StaCorrectCnt, cnt (SV_ID=5)"
+
+  .StaVerifyCnt:
+    @datatype: uWord
+    @default: 20*NUM_AC_CYCLES
+    @description: "StaVerifyCnt, cnt (SV_ID=5)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=5)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "CycleMask, Cycle 1, 3, 5, ... (5 Hz) (SV_ID=5)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, Every Frame 1 - 15 (SV_ID=5)"
+
+  .VelCmdCycleMask:
+    @datatype: uWord
+    @default: { 0x0400 }
+    @description: "VelCmdCycleMask[STA1], Cycle 3 (1 Hz) (SV_ID=5)"
+
+  .VelCmdFrameMask:
+    @datatype: uWord
+    @default: { 0xFFFE }
+    @description: "VelCmdFrameMask[STA1], Every Frame 1 - 15 (SV_ID=5)"
+
+  .StaMesDelay[1]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=6)"
+
+  .StaMesDelay[2]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=6)"
+
+  .IruToAcDelay:
+    @datatype: dReal
+    @default: { 0.0 }
+    @description: "IruToAcDelay (sec) (SV_ID=6)"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: { 3.0 }
+    @description: "WarmUpTime (sec) (SV_ID=6)"
+
+  .CoiScaleFactor:
+    @datatype: dReal
+    @default: { 2.0E-05 }
+    @description: "CoiScaleFactor (sec/count) (SV_ID=6)"
+
+  .LinearVelocityLsbX:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbX (m/s/count) (SV_ID=6)"
+
+  .LinearVelocityLsbY:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbY (m/s/count) (SV_ID=6)"
+
+  .LinearVelocityLsbZ:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbZ (m/s/count) (SV_ID=6)"
+
+  .XYQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "XYQualityIndexLsb (arcsec/count) (SV_ID=6)"
+
+  .ZQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "ZQualityIndexLsb (arcsec/count) (SV_ID=6)"
+
+  .QBdyToSta[1]:
+    @datatype: uQuaternion
+    @default: { 0.595752843342, -0.241359981871, 0.709990316835, 0.287641598987 }
+    @description: "QBdyToSta[STA1] (SV_ID=6)"
+
+  .QBdyToSta[2]:
+    @datatype: uQuaternion
+    @default: { 0.241359981871, -0.595752843342, 0.287641598987, 0.709990316835 }
+    @description: "(SV_ID=6)"
+
+  .StaNoiseCov[1]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=6)"
+
+  .StaNoiseCov[2]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=6)"
+
+  .BoresightSta[1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=6)"
+
+  .BoresightSta[2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=6)"
+
+  .QualityIndexThr[1]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=6)"
+
+  .QualityIndexThr[2]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=6)"
+
+  .VelCmdModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_ACQ_MODE }
+    @description: "VelCmdModeMin (SV_ID=6)"
+
+  .VelCmdModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "VelCmdModeMax (SV_ID=6)"
+
+  .SecondStatusMask:
+    @datatype: uWord
+    @default: { 0x0070 }
+    @description: "SecondStatusMask (Big Endian Bit order) (SV_ID=6)"
+
+  .SecondStatusDesired:
+    @datatype: uWord
+    @default: { 0x0050 }
+    @description: "SecondStatusDesired (Big Endian Bit order) (SV_ID=6)"
+
+  .HealthStatusMask:
+    @datatype: uWord
+    @default: { 0x0FFE }
+    @description: "HealthStatusMask (Big Endian Bit order) (SV_ID=6)"
+
+  .HealtStatusDesired:
+    @datatype: uWord
+    @default: { 0x0000 }
+    @description: "HealthStatusDesired (Big Endian Bit order) (SV_ID=6)"
+
+  .SyntDefOhMask[1]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=6)"
+
+  .SyntDefOhMask[2]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=6)"
+
+  .SyntDefOhDesired[1]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=6)"
+
+  .SyntDefOhDesired[2]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=6)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=6)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_STA_CYCLES
+    @description: "PowerOffCnt, (ACS Cycles) (SV_ID=6)"
+
+  .EarthOccultationThr[1]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=6)"
+
+  .EarthOccultationThr[2]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=6)"
+
+  .SolarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=6)"
+
+  .SolarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=6)"
+
+  .LunarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=6)"
+
+  .LunarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=6)"
+
+  .DataValidityFailCnt[1]:
+    @datatype: uWord
+    @default: 20*NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=6)"
+
+  .DataValidityFailCnt[2]:
+    @datatype: uWord
+    @default: 20 * NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=6)"
+
+  .DataQualityFailCnt[1]:
+    @datatype: uWord
+    @default: 15*MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=6)"
+
+  .DataQualityFailCnt[2]:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=6)"
+
+  .StaDataValidityFailCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "StaDataValidityFailCnt cnt (SV_ID=6)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "PowerStatusOffCnt cnt (SV_ID=6)"
+
+  .OccultationADKFThr:
+    @datatype: uWord
+    @default: { COARSE_CONVERGED }
+    @description: "OccultationADKFThr, (SV_ID=6)"
+
+  .ExpectedOpModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMin[STA1] (SV_ID=6)"
+
+  .ExpectedOpModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMax[STA1] (SV_ID=6)"
+
+  .OhDesiredSeqStatusMin[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=6)"
+
+  .OhDesiredSeqStatusMin[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=6)"
+
+  .OhDesiredSeqStatusMax[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=6)"
+
+  .OhDesiredSeqStatusMax[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=6)"
+
+  .StaCorrectCnt:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "StaCorrectCnt, cnt (SV_ID=6)"
+
+  .StaVerifyCnt:
+    @datatype: uWord
+    @default: 20*NUM_AC_CYCLES
+    @description: "StaVerifyCnt, cnt (SV_ID=6)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=6)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "CycleMask, Cycle 1, 3, 5, ... (5 Hz) (SV_ID=6)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, Every Frame 1 - 15 (SV_ID=6)"
+
+  .VelCmdCycleMask:
+    @datatype: uWord
+    @default: { 0x0400 }
+    @description: "VelCmdCycleMask[STA1], Cycle 3 (1 Hz) (SV_ID=6)"
+
+  .VelCmdFrameMask:
+    @datatype: uWord
+    @default: { 0xFFFE }
+    @description: "VelCmdFrameMask[STA1], Every Frame 1 - 15 (SV_ID=6)"
+
+  .StaMesDelay[1]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=ELSE)"
+
+  .StaMesDelay[2]:
+    @datatype: dReal
+    @default: 262.5E-3
+    @description: "StaMesDelay[STA1], [STA2] (sec) (SV_ID=ELSE)"
+
+  .IruToAcDelay:
+    @datatype: dReal
+    @default: { 0.0 }
+    @description: "IruToAcDelay (sec) (SV_ID=ELSE)"
+
+  .WarmUpTime:
+    @datatype: dReal
+    @default: { 3.0 }
+    @description: "WarmUpTime (sec) (SV_ID=ELSE)"
+
+  .CoiScaleFactor:
+    @datatype: dReal
+    @default: { 2.0E-05 }
+    @description: "CoiScaleFactor (sec/count) (SV_ID=ELSE)"
+
+  .LinearVelocityLsbX:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbX (m/s/count) (SV_ID=ELSE)"
+
+  .LinearVelocityLsbY:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbY (m/s/count) (SV_ID=ELSE)"
+
+  .LinearVelocityLsbZ:
+    @datatype: dReal
+    @default: { 1.0 }
+    @description: "LinearVelocityLsbZ (m/s/count) (SV_ID=ELSE)"
+
+  .XYQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "XYQualityIndexLsb (arcsec/count) (SV_ID=ELSE)"
+
+  .ZQualityIndexLsb:
+    @datatype: dReal
+    @default: { 0.1 }
+    @description: "ZQualityIndexLsb (arcsec/count) (SV_ID=ELSE)"
+
+  .QBdyToSta[1]:
+    @datatype: uQuaternion
+    @default: { 0.595752843342, -0.241359981871, 0.709990316835, 0.287641598987 }
+    @description: "QBdyToSta[STA1] (SV_ID=ELSE)"
+
+  .QBdyToSta[2]:
+    @datatype: uQuaternion
+    @default: { 0.241359981871, -0.595752843342, 0.287641598987, 0.709990316835 }
+    @description: "(SV_ID=ELSE)"
+
+  .StaNoiseCov[1]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=ELSE)"
+
+  .StaNoiseCov[2]:
+    @datatype: uMatrix
+    @default: { { { SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0, 0.0 }, { 0.0, SQR( ( 3.8 / 3.0 ) * ARCSEC_2_RAD ), 0.0 }, { 0.0, 0.0, SQR( ( 31 / 3.0 ) * ARCSEC_2_RAD ) } } }
+    @description: "(SV_ID=ELSE)"
+
+  .BoresightSta[1]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=ELSE)"
+
+  .BoresightSta[2]:
+    @datatype: uVector
+    @default: { { 0.0, 0.0, 1.0 } }
+    @description: "BoresightSta[STA_OH2] (SV_ID=ELSE)"
+
+  .QualityIndexThr[1]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=ELSE)"
+
+  .QualityIndexThr[2]:
+    @datatype: uVector
+    @default: { 60, 60, 600 }
+    @description: "QualityIndexThr[STA_OH2], (arcsec) (SV_ID=ELSE)"
+
+  .VelCmdModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_ACQ_MODE }
+    @description: "VelCmdModeMin (SV_ID=ELSE)"
+
+  .VelCmdModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "VelCmdModeMax (SV_ID=ELSE)"
+
+  .SecondStatusMask:
+    @datatype: uWord
+    @default: { 0x0070 }
+    @description: "SecondStatusMask (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .SecondStatusDesired:
+    @datatype: uWord
+    @default: { 0x0050 }
+    @description: "SecondStatusDesired (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .HealthStatusMask:
+    @datatype: uWord
+    @default: { 0x0FFE }
+    @description: "HealthStatusMask (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .HealtStatusDesired:
+    @datatype: uWord
+    @default: { 0x0000 }
+    @description: "HealthStatusDesired (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .SyntDefOhMask[1]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .SyntDefOhMask[2]:
+    @datatype: uWord
+    @default: 0x007F
+    @description: "SyntDefOhMask[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .SyntDefOhDesired[1]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .SyntDefOhDesired[2]:
+    @datatype: uWord
+    @default: 0x0000
+    @description: "SyntDefOhDesired[STA_OH1], [STA_OH2] (Big Endian Bit order) (SV_ID=ELSE)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=ELSE)"
+
+  .PowerOffCnt:
+    @datatype: uWord
+    @default: 3*NUM_STA_CYCLES
+    @description: "PowerOffCnt, (ACS Cycles) (SV_ID=ELSE)"
+
+  .EarthOccultationThr[1]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=ELSE)"
+
+  .EarthOccultationThr[2]:
+    @datatype: dReal
+    @default: ( 21.0 + 1.0 ) * DEG_2_RAD
+    @description: "*** FDC *** EarthOccultationThr[STA1], rad ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=ELSE)"
+
+  .SolarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=ELSE)"
+
+  .SolarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.882947592858927
+    @description: "SolarOccultationThr[STA1], cos(27.0+1 deg) ( RP__00002103_D__Perf_HYDRA_TC Section 9.3) (SV_ID=ELSE)"
+
+  .LunarOccultationThr[1]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=ELSE)"
+
+  .LunarOccultationThr[2]:
+    @datatype: dReal
+    @default: 0.93969262078591
+    @description: "LunarOccultationThr[STA1], cos(20 deg) (SV_ID=ELSE)"
+
+  .DataValidityFailCnt[1]:
+    @datatype: uWord
+    @default: 20*NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=ELSE)"
+
+  .DataValidityFailCnt[2]:
+    @datatype: uWord
+    @default: 20 * NUM_STA_CYCLES
+    @description: "DataValidityFailCnt[STA1, STA2], cnt (SV_ID=ELSE)"
+
+  .DataQualityFailCnt[1]:
+    @datatype: uWord
+    @default: 15*MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=ELSE)"
+
+  .DataQualityFailCnt[2]:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_STA_CYCLES
+    @description: "DataQualityFailCnt[STA1, STA2], cnt (SV_ID=ELSE)"
+
+  .StaDataValidityFailCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "StaDataValidityFailCnt cnt (SV_ID=ELSE)"
+
+  .PowerStatusOffCnt:
+    @datatype: uWord
+    @default: { 20*NUM_STA_CYCLES }
+    @description: "PowerStatusOffCnt cnt (SV_ID=ELSE)"
+
+  .OccultationADKFThr:
+    @datatype: uWord
+    @default: { COARSE_CONVERGED }
+    @description: "OccultationADKFThr, (SV_ID=ELSE)"
+
+  .ExpectedOpModeMin:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMin[STA1] (SV_ID=ELSE)"
+
+  .ExpectedOpModeMax:
+    @datatype: uWord
+    @default: { STA_AUTO_TRK_MODE }
+    @description: "ExpectedOpModeMax[STA1] (SV_ID=ELSE)"
+
+  .OhDesiredSeqStatusMin[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=ELSE)"
+
+  .OhDesiredSeqStatusMin[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMin [ STA_OH2 ] (SV_ID=ELSE)"
+
+  .OhDesiredSeqStatusMax[1]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=ELSE)"
+
+  .OhDesiredSeqStatusMax[2]:
+    @datatype: uWord
+    @default: { STA_OH_TRACKING }
+    @description: "OhDesiredSeqStatusMax [ STA_OH2 ] (SV_ID=ELSE)"
+
+  .StaCorrectCnt:
+    @datatype: uWord
+    @default: 30*NUM_AC_CYCLES
+    @description: "StaCorrectCnt, cnt (SV_ID=ELSE)"
+
+  .StaVerifyCnt:
+    @datatype: uWord
+    @default: 20*NUM_AC_CYCLES
+    @description: "StaVerifyCnt, cnt (SV_ID=ELSE)"
+
+  .SpareWord:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord (SV_ID=ELSE)"
+
+  .CycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "CycleMask, Cycle 1, 3, 5, ... (5 Hz) (SV_ID=ELSE)"
+
+  .FrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "FrameMask, Every Frame 1 - 15 (SV_ID=ELSE)"
+
+  .VelCmdCycleMask:
+    @datatype: uWord
+    @default: { 0x0400 }
+    @description: "VelCmdCycleMask[STA1], Cycle 3 (1 Hz) (SV_ID=ELSE)"
+
+  .VelCmdFrameMask:
+    @datatype: uWord
+    @default: { 0xFFFE }
+    @description: "VelCmdFrameMask[STA1], Every Frame 1 - 15 (SV_ID=ELSE)"
+
+}
+
+table ac_table_type {
+  @buildstruct!
+  .CycleMax:
+    @datatype: uWord
+    @default: NUM_AC_CYCLES
+    @description: "CycleMax Max 0.10 Sec Cycles (From 1 - 10)"
+
+  .FrameMax:
+    @datatype: uWord
+    @default: 15
+    @description: "FrameMax Max 1.0 Sec Frames (From 1 - 15)"
+
+  .SolarCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "SolarCycleMask, Sun Ephemeris Cycle Mask, Cycle 1"
+
+  .SolarFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "SolarFrameMask, Sun Ephemeris Frame Mask, Every Frame 1 - 15"
+
+  .LunarCycleMask:
+    @datatype: uWord
+    @default: 0x0002
+    @description: "LunarCycleMask, Moon Ephemeris Cycle Mask, Cycle 1"
+
+  .LunarFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "LunarFrameMask, Moon Ephemeris Frame Mask, Every Frame 1 - 15"
+
+  .KFCycleMask:
+    @datatype: uWord
+    @default: 0xAAAA
+    @description: "KFCycleMask, Kalman Filter Cycle Mask, Cycle 1, 3, 5, ... (5 Hz)"
+
+  .KFFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "KFFrameMask, Kalman Filter Frame Mask, Every Frame 1 - 15"
+
+  .AnCmdCycleMask:
+    @datatype: uWord
+    @default: 0x0004
+    @description: "AnCmdCycleMask, AN Command Cycle Mask, Cycle 2"
+
+  .AnCmdFrameMask:
+    @datatype: uWord
+    @default: 0xFFFE
+    @description: "AnCmdFrameMask, AN Command Frame Mask, Every Frame 1 - 15"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .ElapsedTimeDtThr:
+    @datatype: dReal
+    @default: 1.5 * AC_CYCLE_TIME
+    @description: "ElapsedTimeDtThr (sec)"
+
+  .EpochBias:
+    @datatype: dReal
+    @default: 0.0
+    @description: "EpochBias (day)"
+
+  .GHA_J2000:
+    @datatype: dReal
+    @default: 4.89590917379201
+    @description: "GHA_J2000 (rad)"
+
+  .EARTH_RATE:
+    @datatype: dReal
+    @default: 7.2921151467E-05
+    @description: "EARTH_RATE (rad/s) RateNull"
+
+  .OmegaCmd:
+    @datatype: uVector
+    @default: {{ 0.0 * DEG_2_RAD, 0.0 * DEG_2_RAD, 0.0 * DEG_2_RAD }}
+    @description: "OmegaCmd (rad/s)"
+
+  .OmegaErrThr[1]:
+    @datatype: dReal
+    @default: 0.1 * DEG_2_RAD
+    @description: "OmegaErrThr (Nominal) (rad/s)"
+
+  .OmegaErrThr[2]:
+    @datatype: dReal
+    @default: 0.4 * DEG_2_RAD
+    @description: "(IRU Failure) (rad/s)"
+
+  .OmegaSettlingCnt:
+    @datatype: uWord
+    @default: ( 300 * NUM_AC_CYCLES )
+    @description: "OmegaSettlingCnt (cycles)"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[3]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .ThetaErrThr[1]:
+    @datatype: dReal
+    @default: 5.0 * DEG_2_RAD
+    @description: "ThetaErrThr (Nominal) (rad)"
+
+  .ThetaErrThr[2]:
+    @datatype: dReal
+    @default: 5.0 * DEG_2_RAD
+    @description: "(RIU1 Failure) (rad)"
+
+  .OmegaErrThr[1]:
+    @datatype: dReal
+    @default: 0.1 * DEG_2_RAD
+    @description: "OmegaErrThr (Nominal) (rad/s)"
+
+  .OmegaErrThr[2]:
+    @datatype: dReal
+    @default: 0.15 * DEG_2_RAD
+    @description: "(IRU Failure) (rad/s)"
+
+  .ThetaSettlingCnt:
+    @datatype: uWord
+    @default: ( 60 * NUM_AC_CYCLES )
+    @description: "ThetaSettlingCnt (cycles)"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[3]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .OmegaCmd:
+    @datatype: uVector
+    @default: {{ 0.0 * DEG_2_RAD, 0.0 * DEG_2_RAD, 0.0 * DEG_2_RAD }}
+    @description: "OmegaCmd (rad/s)"
+
+  .ThetaOffsetBdyInit:
+    @datatype: uVector
+    @default: {{ 0.0 * DEG_2_RAD, 0.0 * DEG_2_RAD, 0.0 * DEG_2_RAD }}
+    @description: "ThetaOffsetBdyInit (rad)"
+
+  .MaxOffsetAngle:
+    @datatype: dReal
+    @default: 30.0 * DEG_2_RAD
+    @description: "MaxOffsetAngle (rad)"
+
+  .AxisPositiveInit:
+    @datatype: uWord
+    @default: FALSE
+    @description: "AxisPositiveInit: -Z to sun"
+
+  .StartEclipseCount:
+    @datatype: uWord
+    @default: 5 * NUM_AC_CYCLES
+    @description: "StartEclipseCount (cycles)"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .Riu1FaultTestCnt:
+    @datatype: uWord
+    @default: 3 * NUM_AC_CYCLES
+    @description: "Riu1FaultTestCnt, RIU1 Persistency Counter (cycles)"
+
+  .KfNotStartedStateCnt:
+    @datatype: uWord
+    @default: 5 * MIN_2_SEC * NUM_AC_CYCLES
+    @description: "KfNotStartedStateCnt, KF NOT_STARTED Persistency Counter (cycles)"
+
+  .SpareWord[1]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+  .SpareWord[2]:
+    @datatype: uWord
+    @default: 0
+    @description: "SpareWord"
+
+}
+
+table ac_tgt_pnt_table_type {
+  @buildstruct!
+  .OmegaEstMagSqrLmt:
+    @datatype: dReal
+    @default: SQR(0.10 * DEG_2_RAD)
+    @description: "OmegaEstMagSqrLmt, rad/sec"
+
+  .CaptureAngle:
+    @datatype: dReal
+    @default: (1.0 * DEG_2_RAD)
+    @description: "CaptureAngle, rad"
+
+  .OmegaBdyWrtRefMagInc:
+    @datatype: dReal
+    @default: (0.001 * DEG_2_RAD)
+    @description: "OmegaBdyWrtRefMagInc, rad/sec"
+
+  .OmegaSlewLmtInit:
+    @datatype: dReal
+    @default: (0.65 * DEG_2_RAD)
+    @description: "OmegaSlewLmtInit, rad/sec"
+
+  .DeltaQInit:
+    @datatype: uQuaternion
+    @default: {{ 0.00000000000000, 0.00000000000000, 0.00000000000000, 1.00000000000000 }}
+    @description: "DeltaQInit, ND"
+
+  .SadAxisBdy:
+    @datatype: uVector
+    @default: {{ 0.0, 1.0, 0.0 }}
+    @description: "SadAxisBdy, ND"
+
+  .TwoAxisSteeringDeadband:
+    @datatype: dReal
+    @default: (5.0 * DEG_2_RAD)
+    @description: "TwoAxisSteeringDeadband, rad"
+
+  .SmallSlewThr:
+    @datatype: dReal
+    @default: 0.01*DEG_2_RAD
+    @description: "SmallSlewThr, ND"
+
+  .NullOmegaPhaseCnt:
+    @datatype: uWord
+    @default: 15 * MIN_2_SEC*NUM_AC_CYCLES
+    @description: "NullOmegaPhaseCnt, cnt"
+
+  .OmegaSettlingCntInit:
+    @datatype: uWord
+    @default: 30 * NUM_AC_CYCLES
+    @description: "OmegaSettlingCntInit, cnt"
+
+  .EnableResetStopSlewAtt:
+    @datatype: uWord
+    @default: (FALSE)
+    @description: "EnableResetStopSlewAtt, ND"
+
+  .SlewRampTypeInit:
+    @datatype: uWord
+    @default: RAMP_TYPE_LINEAR
+    @description: "SlewRampTypeInit"
+
+}
+
+table ad_table_type {
+  @buildstruct!
+  .PInitial[1][1]:
+    @datatype: dReal
+    @default: SQR( 0.05 * DEG_2_RAD)
+    @description: "[rad^2 ] PInitial[0][0], Gyroed"
+
+  .PInitial[1][2]:
+    @datatype: dReal
+    @default: SQR( 0.05 * DEG_2_RAD)
+    @description: "[rad^2 ] PInitial[0][1], Gyroed"
+
+  .PInitial[1][3]:
+    @datatype: dReal
+    @default: SQR( 0.05 * DEG_2_RAD)
+    @description: "[rad^2 ] PInitial[0][2], Gyroed"
+
+  .PInitial[1][4]:
+    @datatype: dReal
+    @default: SQR( 1.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PInitial[0][3], Gyroed"
+
+  .PInitial[1][5]:
+    @datatype: dReal
+    @default: SQR( 1.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PInitial[0][4], Gyroed"
+
+  .PInitial[1][6]:
+    @datatype: dReal
+    @default: SQR( 1.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PInitial[0][5], Gyroed"
+
+  .PInitial[2][1]:
+    @datatype: dReal
+    @default: SQR( 0.05 * DEG_2_RAD)
+    @description: "[rad^2 ] PInitial[1][0], Gyroless"
+
+  .PInitial[2][2]:
+    @datatype: dReal
+    @default: SQR( 0.05 * DEG_2_RAD)
+    @description: "[rad^2 ] PInitial[1][1], Gyroless"
+
+  .PInitial[2][3]:
+    @datatype: dReal
+    @default: SQR( 0.05 * DEG_2_RAD)
+    @description: "[rad^2 ] PInitial[1][2], Gyroless"
+
+  .PInitial[2][4]:
+    @datatype: dReal
+    @default: SQR( 1.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PInitial[1][3], Gyroless"
+
+  .PInitial[2][5]:
+    @datatype: dReal
+    @default: SQR( 1.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PInitial[1][4], Gyroless"
+
+  .PInitial[2][6]:
+    @datatype: dReal
+    @default: SQR( 1.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PInitial[1][5], Gyroless"
+
+  .PDivergenceThr[1][1]:
+    @datatype: dReal
+    @default: SQR( 0.1 * DEG_2_RAD)
+    @description: "[rad^2 ] PDivergenceThr[0][0], Gyroed"
+
+  .PDivergenceThr[1][2]:
+    @datatype: dReal
+    @default: SQR( 0.1 * DEG_2_RAD)
+    @description: "[rad^2 ] PDivergenceThr[0][1], Gyroed"
+
+  .PDivergenceThr[1][3]:
+    @datatype: dReal
+    @default: SQR( 0.1 * DEG_2_RAD)
+    @description: "[rad^2 ] PDivergenceThr[0][2], Gyroed"
+
+  .PDivergenceThr[1][4]:
+    @datatype: dReal
+    @default: SQR( 15.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PDivergenceThr[0][3], Gyroed"
+
+  .PDivergenceThr[1][5]:
+    @datatype: dReal
+    @default: SQR( 15.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PDivergenceThr[0][4], Gyroed"
+
+  .PDivergenceThr[1][6]:
+    @datatype: dReal
+    @default: SQR( 15.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PDivergenceThr[0][5], Gyroed"
+
+  .PDivergenceThr[2][1]:
+    @datatype: dReal
+    @default: SQR( 0.1 * DEG_2_RAD)
+    @description: "[rad^2 ] PDivergenceThr[1][0], Gyroless"
+
+  .PDivergenceThr[2][2]:
+    @datatype: dReal
+    @default: SQR( 0.1 * DEG_2_RAD)
+    @description: "[rad^2 ] PDivergenceThr[1][1], Gyroless"
+
+  .PDivergenceThr[2][3]:
+    @datatype: dReal
+    @default: SQR( 0.1 * DEG_2_RAD)
+    @description: "[rad^2 ] PDivergenceThr[1][2], Gyroless"
+
+  .PDivergenceThr[2][4]:
+    @datatype: dReal
+    @default: SQR(100.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PDivergenceThr[1][3], Gyroless"
+
+  .PDivergenceThr[2][5]:
+    @datatype: dReal
+    @default: SQR(100.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PDivergenceThr[1][4], Gyroless"
+
+  .PDivergenceThr[2][6]:
+    @datatype: dReal
+    @default: SQR(100.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PDivergenceThr[1][5], Gyroless"
+
+  .PCoarseConvergenceThr[1][1]:
+    @datatype: dReal
+    @default: SQR(25.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PCoarseConvergenceThr[0][0], Gyroed"
+
+  .PCoarseConvergenceThr[1][2]:
+    @datatype: dReal
+    @default: SQR(25.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PCoarseConvergenceThr[0][1], Gyroed"
+
+  .PCoarseConvergenceThr[1][3]:
+    @datatype: dReal
+    @default: SQR(25.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PCoarseConvergenceThr[0][2], Gyroed"
+
+  .PCoarseConvergenceThr[1][4]:
+    @datatype: dReal
+    @default: SQR( 0.7 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PCoarseConvergenceThr[0][3], Gyroed"
+
+  .PCoarseConvergenceThr[1][5]:
+    @datatype: dReal
+    @default: SQR( 0.7 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PCoarseConvergenceThr[0][4], Gyroed"
+
+  .PCoarseConvergenceThr[1][6]:
+    @datatype: dReal
+    @default: SQR( 0.7 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PCoarseConvergenceThr[0][5], Gyroed"
+
+  .PCoarseConvergenceThr[2][1]:
+    @datatype: dReal
+    @default: SQR(50.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PCoarseConvergenceThr[1][0], Gyroless"
+
+  .PCoarseConvergenceThr[2][2]:
+    @datatype: dReal
+    @default: SQR(50.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PCoarseConvergenceThr[1][1], Gyroless"
+
+  .PCoarseConvergenceThr[2][3]:
+    @datatype: dReal
+    @default: SQR(50.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PCoarseConvergenceThr[1][2], Gyroless"
+
+  .PCoarseConvergenceThr[2][4]:
+    @datatype: dReal
+    @default: SQR(10.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PCoarseConvergenceThr[1][3], Gyroless"
+
+  .PCoarseConvergenceThr[2][5]:
+    @datatype: dReal
+    @default: SQR(10.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PCoarseConvergenceThr[1][4], Gyroless"
+
+  .PCoarseConvergenceThr[2][6]:
+    @datatype: dReal
+    @default: SQR(10.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PCoarseConvergenceThr[1][5], Gyroless"
+
+  .PFineConvergenceThr[1][1]:
+    @datatype: dReal
+    @default: SQR( 5.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PFineConvergenceThr[0][0], Gyroed"
+
+  .PFineConvergenceThr[1][2]:
+    @datatype: dReal
+    @default: SQR( 5.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PFineConvergenceThr[0][1], Gyroed"
+
+  .PFineConvergenceThr[1][3]:
+    @datatype: dReal
+    @default: SQR( 5.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PFineConvergenceThr[0][2], Gyroed"
+
+  .PFineConvergenceThr[1][4]:
+    @datatype: dReal
+    @default: SQR( 0.2 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PFineConvergenceThr[0][3], Gyroed"
+
+  .PFineConvergenceThr[1][5]:
+    @datatype: dReal
+    @default: SQR( 0.2 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PFineConvergenceThr[0][4], Gyroed"
+
+  .PFineConvergenceThr[1][6]:
+    @datatype: dReal
+    @default: SQR( 0.2 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PFineConvergenceThr[0][5], Gyroed"
+
+  .PFineConvergenceThr[2][1]:
+    @datatype: dReal
+    @default: SQR(25.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PFineConvergenceThr[1][0], Gyroless"
+
+  .PFineConvergenceThr[2][2]:
+    @datatype: dReal
+    @default: SQR(25.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PFineConvergenceThr[1][1], Gyroless"
+
+  .PFineConvergenceThr[2][3]:
+    @datatype: dReal
+    @default: SQR(25.0 * ARCSEC_2_RAD)
+    @description: "[rad^2 ] PFineConvergenceThr[1][2], Gyroless"
+
+  .PFineConvergenceThr[2][4]:
+    @datatype: dReal
+    @default: SQR( 5.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PFineConvergenceThr[1][3], Gyroless"
+
+  .PFineConvergenceThr[2][5]:
+    @datatype: dReal
+    @default: SQR( 5.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PFineConvergenceThr[1][4], Gyroless"
+
+  .PFineConvergenceThr[2][6]:
+    @datatype: dReal
+    @default: SQR( 5.0 * ARCSEC_2_RAD)
+    @description: "[(rad/sec)^2 ] PFineConvergenceThr[1][5], Gyroless"
+
+  .k[1]:
+    @datatype: dReal
+    @default: 360.0
+    @description: "[ND ] k[0]"
+
+  .k[2]:
+    @datatype: dReal
+    @default: 360.0
+    @description: "[ND ] k[1]"
+
+  .k[3]:
+    @datatype: dReal
+    @default: 360.0
+    @description: "[ND ] k[2]"
+
+  .ResEditAngleThr[1]:
+    @datatype: dReal
+    @default: 180.0 * ARCSEC_2_RAD
+    @description: "[rad ] ResEditAngleThr[0]"
+
+  .ResEditAngleThr[2]:
+    @datatype: dReal
+    @default: 180.0 * ARCSEC_2_RAD
+    @description: "[rad ] ResEditAngleThr[1]"
+
+  .ResEditAngleThr[3]:
+    @datatype: dReal
+    @default: 360.0 * ARCSEC_2_RAD
+    @description: "[rad ] ResEditAngleThr[2]"
+
+  .NoIruQ[1][1][1]:
+    @datatype: dReal
+    @default: 0.33e-08
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][1][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][1][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][1][4]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][1][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][1][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][2][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][2][2]:
+    @datatype: dReal
+    @default: 0.33e-08
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][2][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][2][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][2][5]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][2][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][3][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][3][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][3][3]:
+    @datatype: dReal
+    @default: 0.33e-08
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][3][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][3][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][3][6]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][4][1]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][4][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][4][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][4][4]:
+    @datatype: dReal
+    @default: 0.60e-011
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][4][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][4][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][5][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][5][2]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][5][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][5][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][5][5]:
+    @datatype: dReal
+    @default: 0.60e-011
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][5][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][6][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][6][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][6][3]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][6][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][6][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "SELECT_JET"
+
+  .NoIruQ[1][6][6]:
+    @datatype: dReal
+    @default: 0.60e-11
+    @description: "SELECT_JET"
+
+  .NoIruQ[2][1][1]:
+    @datatype: dReal
+    @default: 0.33e-08
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][1][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][1][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][1][4]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][1][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][1][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][2][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][2][2]:
+    @datatype: dReal
+    @default: 0.33e-08
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][2][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][2][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][2][5]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][2][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][3][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][3][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][3][3]:
+    @datatype: dReal
+    @default: 0.33e-08
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][3][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][3][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][3][6]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][4][1]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][4][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][4][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][4][4]:
+    @datatype: dReal
+    @default: 0.60e-011
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][4][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][4][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][5][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][5][2]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][5][3]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][5][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][5][5]:
+    @datatype: dReal
+    @default: 0.60e-011
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][5][6]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][6][1]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][6][2]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][6][3]:
+    @datatype: dReal
+    @default: -0.30e-11
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][6][4]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][6][5]:
+    @datatype: dReal
+    @default: 0.0
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .NoIruQ[2][6][6]:
+    @datatype: dReal
+    @default: 0.60e-11
+    @description: "Qfinal from DN-STAR-ADCS-015"
+
+  .Kd[1][1]:
+    @datatype: dReal
+    @default: 1.0e-4
+    @description: "SELECT_RWA"
+
+  .Kd[1][2]:
+    @datatype: dReal
+    @default: 1.0e-4
+    @description: "SELECT_RWA"
+
+  .Kd[1][3]:
+    @datatype: dReal
+    @default: 1.0e-4
+    @description: "SELECT_RWA"
+
+  .Kd[2][1]:
+    @datatype: dReal
+    @default: 1.0e-6
+    @description: "SELECT_RWA"
+
+  .Kd[2][2]:
+    @datatype: dReal
+    @default: 1.0e-6
+    @description: "SELECT_RWA"
+
+  .Kd[2][3]:
+    @datatype: dReal
+    @default: 1.0e-6
+    @description: "SELECT_RWA"
+
+  .AlphaDstEstBdyLmt:
+    @datatype: uVector
+    @default: {{ 5.0E-3, 5.0E-3, 5.0E-3 }}
+    @description: "AlphaDstEstBdyLmt, rad/sec^2"
+
+  .SysMomEstBdyLmt:
+    @datatype: uVector
+    @default: {{ 2250000*DEG_2_RAD, 2250000*DEG_2_RAD, 2250000*DEG_2_RAD }}
+    @description: "SysMomEstBdyLmt[2], N-m-s"
+
+  .KStaRateUpdateGain:
+    @datatype: dReal
+    @default: { 0.25 }
+    @description: "KStaRateUpdateGain (SORCE used 0.25)"
+
+  .DisGyroBiasEstInPldState[1]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "DisGyroBiasEstInPldState [True/False ] PD_FAULT"
+
+  .DisGyroBiasEstInPldState[2]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_IDLE"
+
+  .DisGyroBiasEstInPldState[3]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_HOLD"
+
+  .DisGyroBiasEstInPldState[4]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_SLEWING"
+
+  .DisGyroBiasEstInPldState[5]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_TRACKING"
+
+  .DisGyroBiasEstInPldState[6]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_DECELERATE"
+
+  .DisGyroBiasEstInPldState[7]:
+    @datatype: uWord
+    @default: FALSE
+    @description: "[True/False ] PD_TRACK_TABLE"
+
+  .DisGyroBiasEstInPldState[8]:
+    @datatype: uWord
+    @default: TRUE
+    @description: "[True/False ] PD_COMM_ANGLE"
+
+}

--- a/Tables/c_table_to_dbt.py
+++ b/Tables/c_table_to_dbt.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Generate a DBT file from C table definition pairs.
+
+This script scans the current directory for matching `.h` and `.c` files.
+For each pair it parses the table typedef found in the header and the
+corresponding initializer in the source file. The information is written to a
+single DBT file that roughly matches the style of `table_ACS.dbt`.
+
+The heavy lifting of parsing C syntax is delegated to functions from
+`extract_c_tables.py` which already exists in this repository. Only a small
+subset of the DBT format is generated – each field gets a datatype and a
+default value. Comments from the C initializer are used as descriptions when
+present.
+
+The resulting file is written next to this script as ``auto_tables.dbt``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, List, Iterable
+
+# Re-use the non-trivial parsing utilities from extract_c_tables.
+from extract_c_tables import (
+    read_text,
+    build_header_nodes_tree,
+    build_header_nodes,
+    find_alias_initializers,
+    collect_sv_variants,
+    resolve_conditionals_for_variant,
+    split_items_core_at_top,
+    map_nodes_to_items_min,
+    explode_index_and_value,
+    comment_map_for_nodes,
+)
+
+
+def _rows_for_variant(nodes, inner: str, sv_value: str | None) -> List[Dict[str, str]]:
+    """Return rows for one SV_ID variant."""
+    inner_resolved = resolve_conditionals_for_variant(inner, sv_value)
+    core_items = split_items_core_at_top(inner_resolved)
+    flat_rows, _ = map_nodes_to_items_min(nodes, core_items)
+
+    expanded: List[Dict[str, str]] = []
+    for Type, Field, Index, Value in flat_rows:
+        # Expand multi dimensional values into individual rows
+        if Index and Value.strip().startswith("{"):
+            for idx_path, v in explode_index_and_value(Index, Value):
+                expanded.append({"Type": Type, "Field": Field, "Index": idx_path, "Value": v})
+        else:
+            expanded.append({"Type": Type, "Field": Field, "Index": Index, "Value": Value})
+
+    # map comments from initializer
+    c_map = comment_map_for_nodes(nodes, "{" + inner_resolved + "}")
+
+    rows: List[Dict[str, str]] = []
+    for item in expanded:
+        idx = item["Index"]
+        cmt = c_map.get((item["Field"], idx), "")
+        if not cmt and idx:
+            m = re.match(r"(\[\d+\])", idx)
+            if m:
+                cmt = c_map.get((item["Field"], m.group(1)), "") or cmt
+        if not cmt:
+            cmt = c_map.get((item["Field"], "*"), "")
+        if sv_value is not None:
+            suffix = f" (SV_ID={sv_value})"
+        else:
+            suffix = ""
+        rows.append(
+            {
+                "Type": item["Type"],
+                "Field": item["Field"],
+                "Index": item["Index"],
+                "Value": item["Value"],
+                "Description": (cmt + suffix).strip(),
+            }
+        )
+    return rows
+
+
+def process_pair(h_path: Path, c_path: Path) -> Dict[str, List[Dict[str, str]]]:
+    """Return mapping of table name -> rows for a header/source pair."""
+    htxt = read_text(h_path)
+    ctxt = read_text(c_path)
+    typedef_nodes, table_aliases = build_header_nodes_tree(htxt)
+
+    result: Dict[str, List[Dict[str, str]]] = {}
+    for alias, body in table_aliases:
+        nodes = typedef_nodes.get(alias)
+        if nodes is None:
+            nodes = build_header_nodes(body, typedef_nodes)
+        rows: List[Dict[str, str]] = []
+        inits = find_alias_initializers(ctxt, alias)
+        for inner in inits:
+            variants = collect_sv_variants(inner)
+            for sv in variants:
+                rows.extend(_rows_for_variant(nodes, inner, sv))
+        if rows:
+            result[alias] = rows
+    return result
+
+
+def discover_pairs(folder: Path) -> Iterable[tuple[Path, Path]]:
+    hs = {p.stem: p for p in folder.glob("*.h")}
+    cs = {p.stem: p for p in folder.glob("*.c")}
+    for stem in sorted(hs.keys() & cs.keys()):
+        yield hs[stem], cs[stem]
+
+
+def dbt_from_tables(tables: Dict[str, List[Dict[str, str]]]) -> str:
+    lines: List[str] = ["@gsw.subsystem: AUTO", "@classname: FC", ""]
+    for tname, rows in sorted(tables.items()):
+        lines.append(f"table {tname} {{")
+        lines.append("  @buildstruct!")
+        for row in rows:
+            idx = row["Index"]
+            field_name = f"{row['Field']}{idx}" if idx else row["Field"]
+            lines.append(f"  .{field_name}:")
+            lines.append(f"    @datatype: {row['Type']}")
+            lines.append(f"    @default: {row['Value']}")
+            if row["Description"]:
+                lines.append(f"    @description: \"{row['Description']}\"")
+            lines.append("")
+        lines.append("}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    folder = Path(__file__).resolve().parent
+    all_tables: Dict[str, List[Dict[str, str]]] = {}
+    for h, c in discover_pairs(folder):
+        all_tables.update(process_pair(h, c))
+    out_text = dbt_from_tables(all_tables)
+    out_path = folder / "auto_tables.dbt"
+    out_path.write_text(out_text, encoding="utf-8")
+    print(f"Wrote: {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utility to scan `Tables` for matching C headers and sources and emit a DBT description
- produce sample `auto_tables.dbt` generated from the current table files

## Testing
- `python Tables/c_table_to_dbt.py`

------
https://chatgpt.com/codex/tasks/task_e_689f6774fc4c832aaae98b9a889a9348